### PR TITLE
#7 UseEffect部分のリファクタリング

### DIFF
--- a/front/src/app/result/page.tsx
+++ b/front/src/app/result/page.tsx
@@ -3,25 +3,14 @@
 import React, { useEffect, useState } from 'react';
 
 import { Result } from '@/types/result';
-import { fetchData } from '@/lib/api';
 import Loading from '@/components/Loading';
-
+import { useResults } from '@/hooks/useResults';
 import { ResultTable } from '@/app/result/components/ResultTable';
 
 export default function Page() {
-  const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/results`;
-
-  const [results, setResults] = useState<Result[]>([]);
   const [sortedResults, setSortedResults] = useState<Result[]>([]);
 
-  useEffect(() => {
-    const fetchResults = async () => {
-      const data = await fetchData(endpoint, 'GET');
-      setResults(Array.isArray(data) ? data : []);
-    };
-
-    fetchResults();
-  }, [endpoint]);
+  const results = useResults();
 
   useEffect(() => {
     setSortedResults(

--- a/front/src/hooks/useResults.ts
+++ b/front/src/hooks/useResults.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+import { Result } from '@/types/result';
+import { fetchData } from '@/lib/api';
+
+export const useResults = () => {
+  const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/results`;
+
+  const [results, setResults] = useState<Result[]>([]);
+
+  useEffect(() => {
+    const fetchResults = async () => {
+      const data = await fetchData(endpoint, 'GET');
+      setResults(Array.isArray(data) ? data : []);
+    };
+
+    fetchResults();
+  }, [endpoint]);
+
+  return results;
+};


### PR DESCRIPTION
## Issue

#7

## 実施内容

**1. front/src/app/result/page.tsx**
- endpointへfetchするuseEffectの部分をuseResults.tsへ移動
<br>

**2. front/src/hooks/useResults.ts**
- endpointへfetchするuseEffectの部分をpage.tsxから移動