### PR TITLE
shuting/[id]/page.tsxのリファクタリング

### DIFF
--- a/backend_rails/docker-compose.yml
+++ b/backend_rails/docker-compose.yml
@@ -23,7 +23,9 @@ services:
       - app_bundle_volume:/usr/local/bundle
     ports:
       - 3000:3000
-    dns: 
+    depends_on:
+      - db
+    dns:
       - 8.8.8.8
 
 volumes:

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -8,6 +8,10 @@
       "name": "front",
       "version": "0.1.0",
       "dependencies": {
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.0",
+        "@mui/icons-material": "^6.2.1",
+        "@mui/material": "^6.2.1",
         "chart.js": "^4.4.6",
         "howler": "^2.2.4",
         "next": "14.2.15",
@@ -42,16 +46,293 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.3.tgz",
+      "integrity": "sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.26.3",
+        "@babel/types": "^7.26.3",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
+      "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
+      "integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.26.3"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
+      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
+      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.25.9",
+        "@babel/parser": "^7.25.9",
+        "@babel/types": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.26.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.4.tgz",
+      "integrity": "sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.3",
+        "@babel/parser": "^7.26.3",
+        "@babel/template": "^7.25.9",
+        "@babel/types": "^7.26.3",
+        "debug": "^4.3.1",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
+      "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.1.tgz",
+      "integrity": "sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/styled": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.0.tgz",
+      "integrity": "sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/is-prop-valid": "^1.3.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -192,7 +473,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
       "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -206,7 +486,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -215,7 +494,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -223,14 +501,12 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -240,6 +516,248 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
       "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
+    },
+    "node_modules/@mui/core-downloads-tracker": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.2.1.tgz",
+      "integrity": "sha512-U/8vS1+1XiHBnnRRESSG1gvr6JDHdPjrpnW6KEebkAQWBn6wrpbSF/XSZ8/vJIRXH5NyDmMHi4Ro5Q70//JKhA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-6.2.1.tgz",
+      "integrity": "sha512-bP0XtW+t5KFL+wjfQp2UctN/8CuWqF1qaxbYuCAsJhL+AzproM8gGOh2n8sNBcrjbVckzDNqaXqxdpn+OmoWug==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^6.2.1",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.2.1.tgz",
+      "integrity": "sha512-7VlKGsRKsy1bOSOPaSNgpkzaL+0C7iWAVKd2KYyAvhR9fTLJtiAMpq+KuzgEh1so2mtvQERN0tZVIceWMiIesw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mui/core-downloads-tracker": "^6.2.1",
+        "@mui/system": "^6.2.1",
+        "@mui/types": "^7.2.20",
+        "@mui/utils": "^6.2.1",
+        "@popperjs/core": "^2.11.8",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.0.0",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material-pigment-css": "^6.2.1",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@mui/material-pigment-css": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material/node_modules/react-is": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
+      "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g==",
+      "license": "MIT"
+    },
+    "node_modules/@mui/private-theming": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.2.1.tgz",
+      "integrity": "sha512-u1y0gpcfrRRxCcIdVeU5eIvkinA82Q8ft178WUNYuoFQrsOrXdlBdZlRVi+eYuUFp1iXI55Cud7sMZZtETix5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mui/utils": "^6.2.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/styled-engine": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.2.1.tgz",
+      "integrity": "sha512-6R3OgYw6zgCZWFYYMfxDqpGfJA78mUTOIlUDmmJlr60ogVNCrM87X0pqx5TbZ2OwUyxlJxN9qFgRr+J9H6cOBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/system": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.2.1.tgz",
+      "integrity": "sha512-0lc8CbBP4WAAF+SmGMFJI9bpIyQvW3zvwIDzLsb26FIB/4Z0pO7qGe8mkAl0RM63Vb37899qxnThhHKgAAdy6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mui/private-theming": "^6.2.1",
+        "@mui/styled-engine": "^6.2.1",
+        "@mui/types": "^7.2.20",
+        "@mui/utils": "^6.2.1",
+        "clsx": "^2.1.1",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/types": {
+      "version": "7.2.20",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.20.tgz",
+      "integrity": "sha512-straFHD7L8v05l/N5vcWk+y7eL9JF0C2mtph/y4BPm3gn2Eh61dDwDB65pa8DLss3WJfDXYC7Kx5yjP0EmXpgw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.2.1.tgz",
+      "integrity": "sha512-ubLqGIMhKUH2TF/Um+wRzYXgAooQw35th+DPemGrTpgrZHpOgcnUDIDbwsk1e8iQiuJ3mV/ErTtcQrecmlj5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mui/types": "^7.2.20",
+        "@types/prop-types": "^15.7.14",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils/node_modules/react-is": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
+      "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g==",
+      "license": "MIT"
     },
     "node_modules/@next/env": {
       "version": "14.2.15",
@@ -452,6 +970,16 @@
         "node": ">=14"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -499,17 +1027,22 @@
         "undici-types": "~6.19.2"
       }
     },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
-      "version": "15.7.13",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
-      "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
-      "dev": true
+      "version": "15.7.14",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
+      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.11",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
       "integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
-      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -521,6 +1054,15 @@
       "integrity": "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==",
       "dev": true,
       "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "license": "MIT",
+      "peerDependencies": {
         "@types/react": "*"
       }
     },
@@ -1026,6 +1568,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1100,7 +1657,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -1201,6 +1757,15 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1234,12 +1799,43 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/cross-spawn": {
@@ -1271,8 +1867,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -1335,7 +1930,6 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -1444,6 +2038,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -1467,6 +2071,15 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-abstract": {
@@ -1651,7 +2264,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -2164,6 +2776,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -2249,7 +2867,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2514,12 +3131,20 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
       }
     },
     "node_modules/howler": {
@@ -2540,7 +3165,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -2624,6 +3248,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
+    },
     "node_modules/is-async-function": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
@@ -2704,7 +3334,6 @@
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
       "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
-      "dev": true,
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -3067,11 +3696,29 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -3164,8 +3811,7 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -3265,8 +3911,7 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -3427,7 +4072,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3640,12 +4284,29 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/path-exists": {
@@ -3678,8 +4339,7 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
@@ -3702,6 +4362,15 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3940,7 +4609,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -4027,8 +4695,23 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
@@ -4099,7 +4782,6 @@
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -4116,7 +4798,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -4336,6 +5017,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {
@@ -4598,6 +5288,12 @@
         }
       }
     },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
     "node_modules/sucrase": {
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
@@ -4636,7 +5332,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },

--- a/front/package.json
+++ b/front/package.json
@@ -9,6 +9,10 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.0",
+    "@mui/icons-material": "^6.2.1",
+    "@mui/material": "^6.2.1",
     "chart.js": "^4.4.6",
     "howler": "^2.2.4",
     "next": "14.2.15",

--- a/front/package.json
+++ b/front/package.json
@@ -9,7 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@mui/icons-material": "^6.2.1",
     "@mui/material": "^6.2.1",

--- a/front/package.json
+++ b/front/package.json
@@ -9,9 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@emotion/styled": "^11.14.0",
-    "@mui/icons-material": "^6.2.1",
-    "@mui/material": "^6.2.1",
     "chart.js": "^4.4.6",
     "howler": "^2.2.4",
     "next": "14.2.15",

--- a/front/src/app/account/page.tsx
+++ b/front/src/app/account/page.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import React, { useState } from 'react';
-import { patchData } from '@/lib/api';
 import { useValidation } from '@/hooks/useValidation';
-import { ErrorResponse, isErrorResponse } from '@/types/errorResponse';
 
 import { useUser } from '@/context/UserContext';
 import { UserInfo } from '@/types/userInfo';
@@ -14,7 +12,7 @@ import { useUserData } from '@/hooks/useUserData';
 export default function Page() {
   const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/profile`;
 
-  const { userInfo, setUserInfo } = useUser();
+  const { userInfo,  } = useUser();
   const [formData, setFormData] = useState<UserInfo>({
     id: null,
     email: '',
@@ -29,47 +27,21 @@ export default function Page() {
   const { validationErrors, setErrors, clearErrors } = useValidation();
   const [isUpdated, setIsUpdated] = useState(false);
 
-  useUserData(setFormData);
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setFormData({
-      ...formData,
-      [e.target.name]: e.target.value || '',
-    });
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    try {
-      const data = await patchData<UserInfo, UserInfo | ErrorResponse>(endpoint, formData);
-
-      if (isErrorResponse(data) && data.error_type === 'ValidationError') {
-        const errors = data.details ? JSON.parse(data.details) : {};
-        setErrors(errors);
-      } else if (!isErrorResponse(data)) {
-        setUserInfo({
-          ...data,
-          image: userInfo?.image
-        });
-        setFormData(data);
-        clearErrors();
-
-        setIsUpdated(true);
-        setTimeout(() => {
-          setIsUpdated(false);
-        }, 3000);
-      }
-    } catch (error) {
-      console.error('Error updating profile:', error);
-    }
-  };
+  const { handleChange, handleSubmit } = useUserData(
+    setFormData,
+    formData,
+    setErrors,
+    clearErrors,
+    setIsUpdated,
+    endpoint
+  );
 
   if (userInfo) {
     return(
       <div>
         {isUpdated && (
           <div className="
-            py-2 px-4 
+            py-2 px-4
             mb-4
             bg-green-400
             text-white
@@ -103,14 +75,14 @@ export default function Page() {
                 name="name"
                 value={formData.name || ''}
                 onChange={handleChange}
-                onBlur={() => setIsEditing(false)} 
+                onBlur={() => setIsEditing(false)}
                 autoFocus
                 className="
                   mt-1 p-2
-                  border border-gray-300 
-                  rounded 
-                  focus:outline-none 
-                  focus:ring-2 
+                  border border-gray-300
+                  rounded
+                  focus:outline-none
+                  focus:ring-2
                   focus:ring-blue-400
                 "
               />

--- a/front/src/app/account/page.tsx
+++ b/front/src/app/account/page.tsx
@@ -29,7 +29,7 @@ export default function Page() {
   const { validationErrors, setErrors, clearErrors } = useValidation();
   const [isUpdated, setIsUpdated] = useState(false);
 
-  useUserData(endpoint, setFormData);
+  useUserData(setFormData);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFormData({
@@ -118,12 +118,12 @@ export default function Page() {
               <p
                 onClick={handleEditClick}
                 className="
-                  mt-1 p-2 
+                  mt-1 p-2
                   border border-transparent rounded
                   bg-gray-100
                   hover:bg-gray-200 cursor-pointer
                 ">{formData.name || "Click to edit"}</p>
-            )}   
+            )}
             <div className="mb-8" />
           </div>
 

--- a/front/src/app/account/page.tsx
+++ b/front/src/app/account/page.tsx
@@ -9,6 +9,7 @@ import { useUser } from '@/context/UserContext';
 import { UserInfo } from '@/types/userInfo';
 import { BasicButton } from '@/components/Button';
 import { Label } from '@/app/account/components/Lable';
+import { useUserData } from '@/hooks/useUserData';
 
 export default function Page() {
   const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/profile`;
@@ -28,24 +29,7 @@ export default function Page() {
   const { validationErrors, setErrors, clearErrors } = useValidation();
   const [isUpdated, setIsUpdated] = useState(false);
 
-  useEffect(() => {
-    const fetchUserData = async () => {
-      const data = await fetchData<UserInfo | ErrorResponse>(endpoint, 'GET');
-
-      if (isErrorResponse(data)) {
-        console.error('Error fetching user data:', data.message);
-        return;
-      }
-
-      setUserInfo({
-        ...data,
-        image: userInfo?.image
-      });
-      setFormData(data);
-    };
-
-    fetchUserData();
-  }, [endpoint]);
+  useUserData(endpoint, setFormData);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFormData({

--- a/front/src/app/account/page.tsx
+++ b/front/src/app/account/page.tsx
@@ -12,7 +12,7 @@ import { useUserData } from '@/hooks/useUserData';
 export default function Page() {
   const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/profile`;
 
-  const { userInfo,  } = useUser();
+  const { userInfo } = useUser();
   const [formData, setFormData] = useState<UserInfo>({
     id: null,
     email: '',

--- a/front/src/app/account/page.tsx
+++ b/front/src/app/account/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import React, { useEffect, useState } from 'react';
-import { fetchData, patchData } from '@/lib/api';
+import React, { useState } from 'react';
+import { patchData } from '@/lib/api';
 import { useValidation } from '@/hooks/useValidation';
 import { ErrorResponse, isErrorResponse } from '@/types/errorResponse';
 

--- a/front/src/app/pair/gift_request/page.tsx
+++ b/front/src/app/pair/gift_request/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import React, { useState } from 'react';
 import { FaHeart, FaYenSign } from "react-icons/fa"
 import { GiftRequestTable } from '@/app/pair/components/GiftRequestTable';
 import { useGiftRequests } from '@/hooks/useGiftRequests';

--- a/front/src/app/pair/gift_request/page.tsx
+++ b/front/src/app/pair/gift_request/page.tsx
@@ -6,13 +6,13 @@ import { GiftRequestTable } from '@/app/pair/components/GiftRequestTable';
 import { useGiftRequests } from '@/hooks/useGiftRequests';
 
 export default function GiftRequestPage() {
-  enum RequestType {
-    forParents = "ちょうだい！",
-    fromChildren = "あげる",
-  };
-
-  const { myParentsGiftRequests, myChildrenGiftRequests } = useGiftRequests();
-  const [selectedTab, setSelectedTab] = useState<RequestType.forParents | RequestType.fromChildren>(RequestType.forParents);
+  const {
+    myParentsGiftRequests,
+    myChildrenGiftRequests,
+    selectedTab,
+    setSelectedTab,
+    RequestType
+  } = useGiftRequests();
 
   return(
     <>

--- a/front/src/app/pair/gift_request/page.tsx
+++ b/front/src/app/pair/gift_request/page.tsx
@@ -1,57 +1,18 @@
 "use client";
 
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { FaHeart, FaYenSign } from "react-icons/fa"
-
-import { fetchData } from '@/lib/api';
-
 import { GiftRequestTable } from '@/app/pair/components/GiftRequestTable';
-
-import { ErrorResponse, isErrorResponse } from '@/types/errorResponse';
-import { GiftRequests, GiftRequest } from '@/types/pair';
+import { useGiftRequests } from '@/hooks/useGiftRequests';
 
 export default function GiftRequestPage() {
-  const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/gift_requests`;
+  enum RequestType {
+    forParents = "ちょうだい！",
+    fromChildren = "あげる",
+  };
 
-enum RequestType {
-  forParents = "ちょうだい！",
-  fromChildren = "あげる",
-};
-
-  const [
-    giftRequests, 
-    setGiftRequests
-  ] = useState<GiftRequests | null>(null);
-  const [
-    myParentsGiftRequests, 
-    setMyParentsGiftRequests
-  ] = useState<GiftRequest[]>([]);
-  const [
-    myChildrenGiftRequests, 
-    setMyChildrenGiftRequests
-  ] = useState<GiftRequest[]>([]);
-
+  const { myParentsGiftRequests, myChildrenGiftRequests } = useGiftRequests();
   const [selectedTab, setSelectedTab] = useState<RequestType.forParents | RequestType.fromChildren>(RequestType.forParents);
-
-  useEffect(() => {
-    const fetchShutingsData = async () => {
-      const data = await fetchData<GiftRequests | ErrorResponse>(endpoint, 'GET');
-
-      if (isErrorResponse(data)) {
-        console.error('Error fetching shutings data:', data.message);
-        return;
-      }
-
-      setGiftRequests(data);
-    };
-
-    fetchShutingsData();
-  }, []);
-
-  useEffect(() => {
-    setMyParentsGiftRequests(giftRequests?.myParents || []);
-    setMyChildrenGiftRequests(giftRequests?.myChildren || []);
-  }, [giftRequests])
 
   return(
     <>

--- a/front/src/app/pair/page.tsx
+++ b/front/src/app/pair/page.tsx
@@ -1,84 +1,3 @@
-// "use client";
-
-// import React, { useEffect, useState } from 'react';
-
-// import { fetchData } from '@/lib/api';
-// import { useUser } from '@/context/UserContext';
-// import { ErrorResponse, isErrorResponse } from '@/types/errorResponse';
-// import { Relation } from '@/types/pair';
-
-// import { QrCode } from './components/QrCode';
-// import { PairTable } from '@/app/pair/components/PairTable';
-// import { GiftRequest } from '@/app/pair/components/GiftRequest';
-
-// import { SelectedRelation } from '@/types/pair';
-
-// /*
-//  * TODO:
-//  * user_idで招待をしてしまっているので、IDoor問題あり。
-//  * user_idではなく、都度APIをたたいてトークンをparents_childrenに生成。
-//  * 有効期限もつけ、有効な間だけここに表示。
-//  */
-// export default function Page() {
-//   const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/pairs`;
-//   const frontUrl = `${process.env.NEXT_PUBLIC_FRONT_URL}`;
-
-//   const { userInfo } = useUser();
-//   const [relations, setRelations] = useState<Relation[]>([]);
-//   const [invitationUrl, setInvitationUrl] = useState<string | undefined | null>(null);
-
-//   const [isShowModal, setIsShowModal] = useState<boolean>(false);
-//   const [selectedRelation, setSelectedRelation] = useState<SelectedRelation | null>(null); 
-
-//   useEffect(() => {
-//     const fetchUserData = async () => {
-//       const data = await fetchData<Relation[] | ErrorResponse>(endpoint, 'GET');
-
-//       if (isErrorResponse(data)) {
-//         console.error('Error fetching user data:', data.message);
-//         return;
-//       }
-
-//       console.log(data);
-
-//       setRelations(data);
-//     };
-
-//     fetchUserData();
-//   }, []);
-
-//   useEffect(() => {
-//     if (userInfo) {
-//       setInvitationUrl(`${frontUrl}/invitation?inviteChildUserId=${userInfo?.id}`);
-//     }
-//   }, [userInfo]);
-
-//   useEffect(() => {
-//     console.log(isShowModal);
-//   }, [isShowModal]);
-
-//   return(
-//     <>
-//       {isShowModal && selectedRelation
-//         ? <GiftRequest
-//             parentUserId={selectedRelation.parentUserId} 
-//             parentUserName={selectedRelation.parentUserName} 
-//             isShowModal={isShowModal}
-//             setIsShowModal={setIsShowModal}
-//           />
-//         :
-//           <>
-//             <QrCode invitationUrl={invitationUrl} />
-//             <PairTable
-//               relations={relations}
-//               setSelectedRelation={setSelectedRelation}
-//               setIsShowModal={setIsShowModal}
-//             />
-//           </>
-//       }
-//     </>
-//   );
-// }
 "use client";
 import React, { useState } from 'react';
 import { useUser } from '@/context/UserContext';
@@ -93,7 +12,7 @@ export default function Page() {
   const { userInfo } = useUser();
   const { relations, isLoading, error } = usePairRelations();
   const invitationUrl = useInvitationUrl(userInfo);
-  
+
   const [isShowModal, setIsShowModal] = useState(false);
   const [selectedRelation, setSelectedRelation] = useState<SelectedRelation | null>(null);
 

--- a/front/src/app/pair/page.tsx
+++ b/front/src/app/pair/page.tsx
@@ -1,81 +1,129 @@
+// "use client";
+
+// import React, { useEffect, useState } from 'react';
+
+// import { fetchData } from '@/lib/api';
+// import { useUser } from '@/context/UserContext';
+// import { ErrorResponse, isErrorResponse } from '@/types/errorResponse';
+// import { Relation } from '@/types/pair';
+
+// import { QrCode } from './components/QrCode';
+// import { PairTable } from '@/app/pair/components/PairTable';
+// import { GiftRequest } from '@/app/pair/components/GiftRequest';
+
+// import { SelectedRelation } from '@/types/pair';
+
+// /*
+//  * TODO:
+//  * user_idで招待をしてしまっているので、IDoor問題あり。
+//  * user_idではなく、都度APIをたたいてトークンをparents_childrenに生成。
+//  * 有効期限もつけ、有効な間だけここに表示。
+//  */
+// export default function Page() {
+//   const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/pairs`;
+//   const frontUrl = `${process.env.NEXT_PUBLIC_FRONT_URL}`;
+
+//   const { userInfo } = useUser();
+//   const [relations, setRelations] = useState<Relation[]>([]);
+//   const [invitationUrl, setInvitationUrl] = useState<string | undefined | null>(null);
+
+//   const [isShowModal, setIsShowModal] = useState<boolean>(false);
+//   const [selectedRelation, setSelectedRelation] = useState<SelectedRelation | null>(null); 
+
+//   useEffect(() => {
+//     const fetchUserData = async () => {
+//       const data = await fetchData<Relation[] | ErrorResponse>(endpoint, 'GET');
+
+//       if (isErrorResponse(data)) {
+//         console.error('Error fetching user data:', data.message);
+//         return;
+//       }
+
+//       console.log(data);
+
+//       setRelations(data);
+//     };
+
+//     fetchUserData();
+//   }, []);
+
+//   useEffect(() => {
+//     if (userInfo) {
+//       setInvitationUrl(`${frontUrl}/invitation?inviteChildUserId=${userInfo?.id}`);
+//     }
+//   }, [userInfo]);
+
+//   useEffect(() => {
+//     console.log(isShowModal);
+//   }, [isShowModal]);
+
+//   return(
+//     <>
+//       {isShowModal && selectedRelation
+//         ? <GiftRequest
+//             parentUserId={selectedRelation.parentUserId} 
+//             parentUserName={selectedRelation.parentUserName} 
+//             isShowModal={isShowModal}
+//             setIsShowModal={setIsShowModal}
+//           />
+//         :
+//           <>
+//             <QrCode invitationUrl={invitationUrl} />
+//             <PairTable
+//               relations={relations}
+//               setSelectedRelation={setSelectedRelation}
+//               setIsShowModal={setIsShowModal}
+//             />
+//           </>
+//       }
+//     </>
+//   );
+// }
 "use client";
-
-import React, { useEffect, useState } from 'react';
-
-import { fetchData } from '@/lib/api';
+import React, { useState } from 'react';
 import { useUser } from '@/context/UserContext';
-import { ErrorResponse, isErrorResponse } from '@/types/errorResponse';
-import { Relation } from '@/types/pair';
-
 import { QrCode } from './components/QrCode';
 import { PairTable } from '@/app/pair/components/PairTable';
 import { GiftRequest } from '@/app/pair/components/GiftRequest';
-
 import { SelectedRelation } from '@/types/pair';
+import { usePairRelations } from '@/hooks/usePairRelations';
+import { useInvitationUrl } from '@/hooks/useInvitationUrl';
 
-/*
- * TODO:
- * user_idで招待をしてしまっているので、IDoor問題あり。
- * user_idではなく、都度APIをたたいてトークンをparents_childrenに生成。
- * 有効期限もつけ、有効な間だけここに表示。
- */
 export default function Page() {
-  const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/pairs`;
-  const frontUrl = `${process.env.NEXT_PUBLIC_FRONT_URL}`;
-  
   const { userInfo } = useUser();
-  const [relations, setRelations] = useState<Relation[]>([]);
-  const [invitationUrl, setInvitationUrl] = useState<string | undefined | null>(null);
+  const { relations, isLoading, error } = usePairRelations();
+  const invitationUrl = useInvitationUrl(userInfo);
+  
+  const [isShowModal, setIsShowModal] = useState(false);
+  const [selectedRelation, setSelectedRelation] = useState<SelectedRelation | null>(null);
 
-  const [isShowModal, setIsShowModal] = useState<boolean>(false);
-  const [selectedRelation, setSelectedRelation] = useState<SelectedRelation | null>(null); 
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
 
-  useEffect(() => {
-    const fetchUserData = async () => {
-      const data = await fetchData<Relation[] | ErrorResponse>(endpoint, 'GET');
+  if (error) {
+    return <div>Error: {error}</div>;
+  }
 
-      if (isErrorResponse(data)) {
-        console.error('Error fetching user data:', data.message);
-        return;
-      }
-
-      console.log(data);
-
-      setRelations(data);
-    };
-
-    fetchUserData();
-  }, []);
-
-  useEffect(() => {
-    if (userInfo) {
-      setInvitationUrl(`${frontUrl}/invitation?inviteChildUserId=${userInfo?.id}`);
-    }
-  }, [userInfo]);
-
-  useEffect(() => {
-    console.log(isShowModal);
-  }, [isShowModal]);
-
-  return(
+  return (
     <>
-      {isShowModal && selectedRelation
-        ? <GiftRequest
-            parentUserId={selectedRelation.parentUserId} 
-            parentUserName={selectedRelation.parentUserName} 
-            isShowModal={isShowModal}
+      {isShowModal && selectedRelation ? (
+        <GiftRequest
+          parentUserId={selectedRelation.parentUserId}
+          parentUserName={selectedRelation.parentUserName}
+          isShowModal={isShowModal}
+          setIsShowModal={setIsShowModal}
+        />
+      ) : (
+        <>
+          <QrCode invitationUrl={invitationUrl} />
+          <PairTable
+            relations={relations}
+            setSelectedRelation={setSelectedRelation}
             setIsShowModal={setIsShowModal}
           />
-        :
-          <>
-            <QrCode invitationUrl={invitationUrl} />
-            <PairTable
-              relations={relations}
-              setSelectedRelation={setSelectedRelation}
-              setIsShowModal={setIsShowModal}
-            />
-          </>
-      }
+        </>
+      )}
     </>
   );
 }

--- a/front/src/app/result/[id]/page.tsx
+++ b/front/src/app/result/[id]/page.tsx
@@ -1,15 +1,14 @@
 "use client"
 
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useParams } from 'next/navigation';
 
-import { fetchData } from '@/lib/api';
 import { Result } from '@/types/result';
 import { Description } from '@/app/result/components/Description';
 import { Chart } from '@/app/result/components/Chart';
 import Loading from "@/components/Loading";
-import { isErrorResponse } from '@/types/errorResponse';
 import { BasicButton } from "@/components/Button";
+import { useResultData } from '@/hooks/useResultData';
 
 export default function Page() {
   const [result, setResult] = useState<Result | null>(null);
@@ -20,36 +19,13 @@ export default function Page() {
   const resultEndpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/results/${id}`;
   const recordsEndpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/shutings/${result?.shuting_id}/results`;
 
-  useEffect(() => {
-    const fetchResult = async () => {
-      const data = await fetchData(resultEndpoint, 'GET');
-
-      if (isErrorResponse(data)) {
-        console.error('Error fetching result data:', data.message);
-	return;
-      }
-
-      setResult(data as Result);
-    };
-
-    fetchResult();
-  }, [resultEndpoint]);
-
-  useEffect(() => {
-    if (result && result?.shuting_id) {
-      const fetchRecords = async () => {
-        const data = await fetchData(recordsEndpoint, 'GET');
-
-        if (Array.isArray(data) && data.every(item => !isErrorResponse(item))) {
-          setRecords(data);
-        } else {
-          console.error('Error fetching records data');
-        }
-      };
-
-      fetchRecords();
-    }
-  }, [result, recordsEndpoint]);
+  useResultData(
+    resultEndpoint,
+    recordsEndpoint,
+    setResult,
+    setRecords,
+    result
+  );
 
   return (
     <div className="justify-center min-h-screen">
@@ -63,8 +39,8 @@ export default function Page() {
           ">レベル{result.shuting_id}</h1>
           <Chart records={records} />
           <Description result={result} />
-          <BasicButton 
-            text='チャレンジ'
+          <BasicButton
+             text='チャレンジ'
             url={`/shuting/${result.shuting_id}`}
           />
         </div>

--- a/front/src/app/shuting/page.tsx
+++ b/front/src/app/shuting/page.tsx
@@ -1,34 +1,16 @@
 "use client";
 
-import { 
-  useState, 
-  useEffect, 
-} from 'react';
+import { useState } from 'react';
 import Link from 'next/link';
 
-import { fetchData } from '@/lib/api';
-import { ErrorResponse, isErrorResponse } from '@/types/errorResponse';
 import { Shuting } from '@/types/shuting';
+import { useShutings } from '@/hooks/useShutings';
 
 export default function Page() {
   const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/shutings`;
-
   const [shutings, setShutings] = useState<Shuting[]>([]);
 
-  useEffect(() => {
-    const fetchShutingsData = async () => {
-      const data = await fetchData<Shuting[] | ErrorResponse>(endpoint, 'GET');
-
-      if (isErrorResponse(data)) {
-        console.error('Error fetching shutings data:', data.message);
-        return;
-      }
-
-      setShutings(data);
-    };
-
-    fetchShutingsData();
-  }, []);
+  useShutings(endpoint, setShutings);
 
   return(
     <div>
@@ -57,7 +39,7 @@ const ShutingItem = ({
 }) => {
   return (
     <Link href={`/shuting/${shuting_id}`} key="1">
-      <div 
+      <div
         className="
           h-32
           bg-orange-50

--- a/front/src/context/ConfigContext.tsx
+++ b/front/src/context/ConfigContext.tsx
@@ -16,7 +16,6 @@ type ConfigContextType = {
 };
 
 const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/config`;
-// const endpoint = "http://localhost:3000/api/v1/config";
 
 const ConfigContext = createContext<ConfigContextType | null>(null);
 

--- a/front/src/context/ConfigContext.tsx
+++ b/front/src/context/ConfigContext.tsx
@@ -15,7 +15,9 @@ type ConfigContextType = {
   setConfig: React.Dispatch<React.SetStateAction<ConfigItem[]>>;
 };
 
-const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/config`;
+// const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/config`;
+const endpoint = "http://localhost:3000/api/v1/config";
+
 const ConfigContext = createContext<ConfigContextType | null>(null);
 
 export const ConfigProvider = ({ children }: { children: ReactNode }) => {

--- a/front/src/context/ConfigContext.tsx
+++ b/front/src/context/ConfigContext.tsx
@@ -15,8 +15,8 @@ type ConfigContextType = {
   setConfig: React.Dispatch<React.SetStateAction<ConfigItem[]>>;
 };
 
-// const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/config`;
-const endpoint = "http://localhost:3000/api/v1/config";
+const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/config`;
+// const endpoint = "http://localhost:3000/api/v1/config";
 
 const ConfigContext = createContext<ConfigContextType | null>(null);
 

--- a/front/src/hooks/useGameState.ts
+++ b/front/src/hooks/useGameState.ts
@@ -1,0 +1,118 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { postData } from '@/lib/api';
+import { Word } from '@/types/shuting';
+import { Result } from '@/types/result';
+import { isErrorResponse } from '@/types/errorResponse';
+import { SoundManager } from '@/app/shuting/components/soundManager';
+import { UserInfo } from '@/types/userInfo';
+
+export const useGameState = (
+  postEndpoint: string,
+  shutingWords: Word[],
+  currentIndex: number,
+  isStart: boolean,
+  time: number,
+  perfectCount: number,
+  result: Result,
+  soundManager: SoundManager,
+  setTime: React.Dispatch<React.SetStateAction<number>>,
+  setIsStart: React.Dispatch<React.SetStateAction<boolean>>,
+  setIsFinish: React.Dispatch<React.SetStateAction<boolean>>,
+  setCurrentWord: React.Dispatch<React.SetStateAction<Word | null>>,
+  setAnswer: React.Dispatch<React.SetStateAction<string>>,
+  setCurrentIndex: React.Dispatch<React.SetStateAction<number>>,
+  setMatchLength: React.Dispatch<React.SetStateAction<number>>,
+  setShutingLimitSec: React.Dispatch<React.SetStateAction<number | null>>,
+  setResult: React.Dispatch<React.SetStateAction<Result>>,
+  setIsFinishOverlayVisible: React.Dispatch<React.SetStateAction<boolean>>,
+  setUserInfo: (updater: (prev: UserInfo | null) => UserInfo | null) => void
+  // setUserInfo: (updater: (prev: any) => any) => void
+) => {
+  const router = useRouter();
+
+  // タイマー用のuseEffect
+  useEffect(() => {
+    let interval: NodeJS.Timeout | undefined;
+
+    if (isStart) {
+      interval = setInterval(() => {
+        setTime((prevTime) => prevTime + 1);
+      }, 1000);
+    } else if (!isStart && time !== 0) {
+      clearInterval(interval);
+    }
+
+    return () => clearInterval(interval);
+  }, [isStart, time, setTime]);
+
+  // 次の問題へ移動する関数
+  const moveToNextExample = () => {
+    const nextIndex = currentIndex + 1;
+
+    if (nextIndex < shutingWords.length) {
+      setCurrentWord(shutingWords[nextIndex]);
+      setAnswer('');
+      setCurrentIndex(nextIndex);
+      setMatchLength(0);
+      setShutingLimitSec(shutingWords[nextIndex].limit_sec || null);
+    } else {
+      handleFinish();
+    }
+  };
+
+  // ゲーム開始関数
+  const handleStart = () => {
+    setTime(0);
+    setIsStart(true);
+    soundManager.playBgm();
+  };
+
+  // ゲーム終了関数
+  const handleFinish = async () => {
+    setIsStart(false);
+    setIsFinish(true);
+    soundManager.stopBgm();
+    soundManager.playFinish();
+
+    const finalResult: Result = {
+      ...result,
+      time: time,
+      perfect_count: perfectCount,
+    };
+
+    try {
+      const data: Result = await postData(postEndpoint, finalResult);
+      if (isErrorResponse(data)) {
+        console.error('API Error:', data.message);
+      } else if (data && 'id' in data) {
+        setResult(prev => ({
+          ...prev,
+          score: data.score,
+          time_bonus: data.time_bonus
+        }));
+	
+        setUserInfo((prev) => ({
+          ...prev,
+          id: prev?.id ?? null,
+          point: data.point ?? 0,
+          total_point: prev?.total_point ?? 0,
+        }));
+
+        setIsFinishOverlayVisible(true);
+        await new Promise(resolve => setTimeout(resolve, 5000));
+        setIsFinishOverlayVisible(false);
+
+        router.push(`/result/${data.id}`);
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return {
+    moveToNextExample,
+    handleStart,
+    handleFinish
+  };
+};

--- a/front/src/hooks/useGameState.ts
+++ b/front/src/hooks/useGameState.ts
@@ -27,7 +27,6 @@ export const useGameState = (
   setResult: React.Dispatch<React.SetStateAction<Result>>,
   setIsFinishOverlayVisible: React.Dispatch<React.SetStateAction<boolean>>,
   setUserInfo: (updater: (prev: UserInfo | null) => UserInfo | null) => void
-  // setUserInfo: (updater: (prev: any) => any) => void
 ) => {
   const router = useRouter();
 

--- a/front/src/hooks/useGiftRequests.ts
+++ b/front/src/hooks/useGiftRequests.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import { fetchData } from '@/lib/api';
+import { ErrorResponse, isErrorResponse } from '@/types/errorResponse';
+import { GiftRequests, GiftRequest } from '@/types/pair';
+
+export const useGiftRequests = () => {
+  const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/gift_requests`;
+  const [giftRequests, setGiftRequests] = useState<GiftRequests | null>(null);
+  const [myParentsGiftRequests, setMyParentsGiftRequests] = useState<GiftRequest[]>([]);
+  const [myChildrenGiftRequests, setMyChildrenGiftRequests] = useState<GiftRequest[]>([]);
+
+  useEffect(() => {
+    const fetchGiftRequestsData = async () => {
+      const data = await fetchData<GiftRequests | ErrorResponse>(endpoint, 'GET');
+
+      if (isErrorResponse(data)) {
+        console.error('Error fetching gift requests data:', data.message);
+        return;
+      }
+
+      setGiftRequests(data);
+    };
+
+    fetchGiftRequestsData();
+  }, []);
+
+  useEffect(() => {
+    setMyParentsGiftRequests(giftRequests?.myParents || []);
+    setMyChildrenGiftRequests(giftRequests?.myChildren || []);
+  }, [giftRequests]);
+
+  return {
+    myParentsGiftRequests,
+    myChildrenGiftRequests
+  };
+};

--- a/front/src/hooks/useGiftRequests.ts
+++ b/front/src/hooks/useGiftRequests.ts
@@ -28,7 +28,7 @@ export const useGiftRequests = () => {
     };
 
     fetchGiftRequestsData();
-  }, []);
+  }, [endpoint]);
 
   useEffect(() => {
     setMyParentsGiftRequests(giftRequests?.myParents || []);

--- a/front/src/hooks/useGiftRequests.ts
+++ b/front/src/hooks/useGiftRequests.ts
@@ -3,11 +3,17 @@ import { fetchData } from '@/lib/api';
 import { ErrorResponse, isErrorResponse } from '@/types/errorResponse';
 import { GiftRequests, GiftRequest } from '@/types/pair';
 
+export enum RequestType {
+  forParents = "ちょうだい！",
+  fromChildren = "あげる",
+}
+
 export const useGiftRequests = () => {
   const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/gift_requests`;
   const [giftRequests, setGiftRequests] = useState<GiftRequests | null>(null);
   const [myParentsGiftRequests, setMyParentsGiftRequests] = useState<GiftRequest[]>([]);
   const [myChildrenGiftRequests, setMyChildrenGiftRequests] = useState<GiftRequest[]>([]);
+  const [selectedTab, setSelectedTab] = useState<RequestType>(RequestType.forParents);
 
   useEffect(() => {
     const fetchGiftRequestsData = async () => {
@@ -31,6 +37,9 @@ export const useGiftRequests = () => {
 
   return {
     myParentsGiftRequests,
-    myChildrenGiftRequests
+    myChildrenGiftRequests,
+    selectedTab,
+    setSelectedTab,
+    RequestType
   };
 };

--- a/front/src/hooks/useInvitationUrl.ts
+++ b/front/src/hooks/useInvitationUrl.ts
@@ -1,0 +1,15 @@
+import { useState, useEffect } from 'react';
+import { UserInfo } from '@/types/userInfo';
+
+export const useInvitationUrl = (userInfo: UserInfo | null) => {
+  const [invitationUrl, setInvitationUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (userInfo) {
+      const frontUrl = process.env.NEXT_PUBLIC_FRONT_URL;
+      setInvitationUrl(`${frontUrl}/invitation?inviteChildUserId=${userInfo.id}`);
+    }
+  }, [userInfo]);
+
+  return invitationUrl;
+};

--- a/front/src/hooks/usePairRelations.ts
+++ b/front/src/hooks/usePairRelations.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect } from 'react';
+import { fetchData } from '@/lib/api';
+import { Relation } from '@/types/pair';
+import { ErrorResponse, isErrorResponse } from '@/types/errorResponse';
+
+export const usePairRelations = () => {
+  const [relations, setRelations] = useState<Relation[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/pairs`;
+
+  useEffect(() => {
+    const fetchRelations = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const data = await fetchData<Relation[] | ErrorResponse>(endpoint, 'GET');
+
+        if (isErrorResponse(data)) {
+          setError(data.message || data.error_type || 'Unknown error');
+          return;
+        }
+
+        setRelations(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'An error occurred');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchRelations();
+  }, []);
+
+  return { relations, isLoading, error };
+};

--- a/front/src/hooks/useResultData.ts
+++ b/front/src/hooks/useResultData.ts
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+import { fetchData } from '@/lib/api';
+import { Result } from '@/types/result';
+import { isErrorResponse } from '@/types/errorResponse';
+
+export const useResultData = (
+  resultEndpoint: string,
+  recordsEndpoint: string,
+  setResult: React.Dispatch<React.SetStateAction<Result | null>>,
+  setRecords: React.Dispatch<React.SetStateAction<Result[]>>,
+  result: Result | null
+) => {
+  // 結果データを取得するuseEffect
+  useEffect(() => {
+    const fetchResult = async () => {
+      const data = await fetchData(resultEndpoint, 'GET');
+
+      if (isErrorResponse(data)) {
+        console.error('Error fetching result data:', data.message);
+        return;
+      }
+
+      setResult(data as Result);
+    };
+
+    fetchResult();
+  }, [resultEndpoint, setResult]);
+
+  // 履歴データを取得するuseEffect
+  useEffect(() => {
+    if (result && result?.shuting_id) {
+      const fetchRecords = async () => {
+        const data = await fetchData(recordsEndpoint, 'GET');
+
+        if (Array.isArray(data) && data.every(item => !isErrorResponse(item))) {
+          setRecords(data);
+        } else {
+          console.error('Error fetching records data');
+        }
+      };
+
+      fetchRecords();
+    }
+  }, [result, recordsEndpoint, setRecords]);
+};

--- a/front/src/hooks/useShutingData.ts
+++ b/front/src/hooks/useShutingData.ts
@@ -1,0 +1,46 @@
+import { useEffect } from 'react';
+import { fetchData } from '@/lib/api';
+import { Shuting, Word } from '@/types/shuting';
+import { isErrorResponse } from '@/types/errorResponse';
+import { SoundManager } from '@/app/shuting/components/soundManager';
+
+export const useShutingData = (
+  getEndpoint: string,
+  currentIndex: number,
+  setShutingWords: React.Dispatch<React.SetStateAction<Word[]>>,
+  setCurrentWord: React.Dispatch<React.SetStateAction<Word | null>>,
+  setShutingLimitSec: React.Dispatch<React.SetStateAction<number | null>>,
+  soundManager: SoundManager
+) => {
+  // データ取得用のuseEffect
+  useEffect(() => {
+    const fetchShutings = async () => {
+      const data: Shuting = await fetchData(getEndpoint, 'GET');
+
+      if (isErrorResponse(data)) {
+        console.error('Error fetching lesson data:', data.message);
+        return;
+      };
+
+      console.log(data.words)
+
+      if (Array.isArray(data.words)) {
+        const words: Word[] = data.is_random
+          ? [...data.words].sort(() => Math.random() - 0.5)
+          : data.words;
+
+        setShutingWords(words);
+        setCurrentWord(words[currentIndex]);
+        setShutingLimitSec(words[currentIndex]?.limit_sec);
+      } else {
+        console.error("Expected an array of words, received:", data.words);
+      }
+    };
+
+    fetchShutings();
+
+    soundManager.playReadyGo();
+  // マウント時に一度だけデータを取得したいため、依存配列は空にしています
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+};

--- a/front/src/hooks/useShutings.ts
+++ b/front/src/hooks/useShutings.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { fetchData } from '@/lib/api';
+import { ErrorResponse, isErrorResponse } from '@/types/errorResponse';
+import { Shuting } from '@/types/shuting';
+
+export const useShutings = (
+  endpoint: string,
+  setShutings: React.Dispatch<React.SetStateAction<Shuting[]>>
+) => {
+  useEffect(() => {
+    const fetchShutingsData = async () => {
+      const data = await fetchData<Shuting[] | ErrorResponse>(endpoint, 'GET');
+
+      if (isErrorResponse(data)) {
+        console.error('Error fetching shutings data:', data.message);
+        return;
+      }
+
+      setShutings(data);
+    };
+
+    fetchShutingsData();
+  }, [endpoint, setShutings]);
+};

--- a/front/src/hooks/useUserData.ts
+++ b/front/src/hooks/useUserData.ts
@@ -4,7 +4,8 @@ import { UserInfo } from '@/types/userInfo';
 import { ErrorResponse, isErrorResponse } from '@/types/errorResponse';
 import { useUser } from '@/context/UserContext';
 
-export const useUserData = (endpoint: string, setFormData: (data: UserInfo) => void) => {
+export const useUserData = (setFormData: (data: UserInfo) => void) => {
+  const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/profile`;
   const { userInfo, setUserInfo } = useUser();
 
   useEffect(() => {
@@ -24,5 +25,7 @@ export const useUserData = (endpoint: string, setFormData: (data: UserInfo) => v
     };
 
     fetchUserData();
-  }, [endpoint, setUserInfo, userInfo?.image, setFormData]);
+  }, [setUserInfo, userInfo?.image]);
+
+  return { endpoint, setFormData };
 };

--- a/front/src/hooks/useUserData.ts
+++ b/front/src/hooks/useUserData.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import { fetchData } from '@/lib/api';
+import { UserInfo } from '@/types/userInfo';
+import { ErrorResponse, isErrorResponse } from '@/types/errorResponse';
+import { useUser } from '@/context/UserContext';
+
+export const useUserData = (endpoint: string, setFormData: (data: UserInfo) => void) => {
+  const { userInfo, setUserInfo } = useUser();
+
+  useEffect(() => {
+    const fetchUserData = async () => {
+      const data = await fetchData<UserInfo | ErrorResponse>(endpoint, 'GET');
+
+      if (isErrorResponse(data)) {
+        console.error('Error fetching user data:', data.message);
+        return;
+      }
+
+      setUserInfo({
+        ...data,
+        image: userInfo?.image
+      });
+      setFormData(data);
+    };
+
+    fetchUserData();
+  }, [endpoint, setUserInfo, userInfo?.image, setFormData]);
+};

--- a/front/src/hooks/useUserData.ts
+++ b/front/src/hooks/useUserData.ts
@@ -1,11 +1,21 @@
 import { useEffect } from 'react';
-import { fetchData } from '@/lib/api';
+import { fetchData, patchData } from '@/lib/api';
 import { UserInfo } from '@/types/userInfo';
 import { ErrorResponse, isErrorResponse } from '@/types/errorResponse';
 import { useUser } from '@/context/UserContext';
 
-export const useUserData = (setFormData: (data: UserInfo) => void) => {
-  const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/profile`;
+type ValidationError = {
+  [key: string]: string[];
+};
+
+export const useUserData = (
+  setFormData: (data: UserInfo) => void,
+  formData: UserInfo,
+  setErrors: (errors: ValidationError) => void,
+  clearErrors: () => void,
+  setIsUpdated: (isUpdated: boolean) => void,
+  endpoint: string
+) => {
   const { userInfo, setUserInfo } = useUser();
 
   useEffect(() => {
@@ -25,7 +35,39 @@ export const useUserData = (setFormData: (data: UserInfo) => void) => {
     };
 
     fetchUserData();
-  }, [setUserInfo, userInfo?.image]);
+  }, [endpoint, setFormData, setUserInfo, userInfo?.image]);
 
-  return { endpoint, setFormData };
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData({
+      ...formData,
+      [e.target.name]: e.target.value || '',
+    });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const data = await patchData<UserInfo, UserInfo | ErrorResponse>(endpoint, formData);
+
+      if (isErrorResponse(data) && data.error_type === 'ValidationError') {
+        const errors = data.details ? JSON.parse(data.details) : {};
+        setErrors(errors);
+      } else if (!isErrorResponse(data)) {
+        setUserInfo({
+          ...data,
+          image: userInfo?.image
+        });
+        setFormData(data);
+        clearErrors();
+
+        setIsUpdated(true);
+        setTimeout(() => {
+          setIsUpdated(false);
+        }, 3000);
+      }
+    } catch (error) {
+      console.error('Error updating profile:', error);
+    }
+  };
+  return { handleChange, handleSubmit };
 };


### PR DESCRIPTION
# WHY
https://github.com/yokohama/typing/issues/8

# WHAT
useShutingData.tsとuseGameState.tsのカスタムフックを作成して、ロジックを移動させて再利用できるようにして
pageコンポーネントをシンプルにしました。

- useShutingData フック
データ取得に関連するuseEffectを分離
単語データの取得と初期設定を担当
必要な状態と関数を引数として受け取る
- useGameState フック
ゲームのロジックに関連するuseEffectを分離
タイマー管理、ゲーム進行、結果処理などを担当
moveToNextExample、handleStart、handleFinishの関数を提供
- ページコンポーネント
元の状態管理とUIレンダリングはそのまま維持
カスタムフックを呼び出して、特定のロジックを受け渡し