### PR TITLE
プレーヤーランキングページの作成

### DIFF
--- a/backend_rails/docker-compose.yml
+++ b/backend_rails/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       dockerfile: Dockerfile
     environment:
       EDITOR: vi
+      CORS_ORIGINS: http://localhost:3001
     volumes:
       - .:/opt/app
       - app_bundle_volume:/usr/local/bundle

--- a/backend_rails/docker-compose.yml
+++ b/backend_rails/docker-compose.yml
@@ -23,7 +23,9 @@ services:
       - app_bundle_volume:/usr/local/bundle
     ports:
       - 3000:3000
-    dns: 
+    depends_on:
+      - db
+    dns:
       - 8.8.8.8
 
 volumes:

--- a/front/next.config.mjs
+++ b/front/next.config.mjs
@@ -7,6 +7,14 @@ const nextConfig = {
         protocol: 'https',
         hostname: 'lh3.googleusercontent.com',
       },
+      {
+        protocol: 'https',
+        hostname: 'api.dicebear.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'avatars.dicebear.com',
+      },
     ],
   },
 };

--- a/front/package.json
+++ b/front/package.json
@@ -9,9 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@emotion/styled": "^11.14.0",
-    "@mui/icons-material": "^6.2.1",
-    "@mui/material": "^6.2.1",
     "chart.js": "^4.4.6",
     "howler": "^2.2.4",
     "next": "14.2.15",

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { SessionProvider } from 'next-auth/react';
 import { ConfigProvider } from '@/context/ConfigContext';
 import { AlertProvider } from '@/context/AlertContext';
 import { UserProvider } from '@/context/UserContext';
+import { BackButtonProvider } from '@/context/BackButtonContext';
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import { Alert } from '@/components/Alert';
@@ -29,8 +30,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="ja" className={`${notoSansJP.className} ${inter.className}`}>
       <head>
-        <meta 
-          httpEquiv="Content-Security-Policy" 
+        <meta
+          httpEquiv="Content-Security-Policy"
           content="trusted-types nextjs#bundler;" />
       </head>
       <body className="bg-yellow-50 text-gray-900">
@@ -38,14 +39,16 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <AlertProvider>
             <SessionProvider>
               <UserProvider>
-                <Header />
-                <main className="
-                  max-w-7xl mx-auto p-4 sm:p-6 lg:p-8
-                ">
-                  <Alert />
-                  {children}
-                </main>
-                <Footer />
+                <BackButtonProvider>
+                  <Header />
+                  <main className="
+                    max-w-7xl mx-auto p-4 sm:p-6 lg:p-8
+                  ">
+                    <Alert />
+                    {children}
+                  </main>
+                  <Footer />
+                </BackButtonProvider>
               </UserProvider>
             </SessionProvider>
           </AlertProvider>

--- a/front/src/app/loading-test/page.tsx
+++ b/front/src/app/loading-test/page.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import React, { useState } from 'react';
+import Loading from '@/components/Loading';
+
+export default function LoadingTest() {
+  // sizeの型を明示的に指定
+  const [size, setSize] = useState<"small" | "medium" | "large">("medium");
+  const [color, setColor] = useState('#6366F1');
+
+  const colors = [
+    { name: 'インディゴ', value: '#6366F1' },
+    { name: '赤', value: '#EF4444' },
+    { name: '緑', value: '#10B981' },
+    { name: '青', value: '#3B82F6' },
+    { name: '黄', value: '#F59E0B' },
+    { name: 'ピンク', value: '#EC4899' }
+  ];
+
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold mb-6">ローディングテスト</h1>
+
+      <div className="mb-6">
+        <h2 className="font-semibold mb-2">サイズ:</h2>
+        <div className="flex gap-2 mb-4">
+          <button
+            onClick={() => setSize('small')}
+            className={`px-4 py-2 rounded ${size === 'small' ? 'bg-blue-500 text-white' : 'bg-gray-200'}`}
+          >
+            Small
+          </button>
+          <button
+            onClick={() => setSize('medium')}
+            className={`px-4 py-2 rounded ${size === 'medium' ? 'bg-blue-500 text-white' : 'bg-gray-200'}`}
+          >
+            Medium
+          </button>
+          <button
+            onClick={() => setSize('large')}
+            className={`px-4 py-2 rounded ${size === 'large' ? 'bg-blue-500 text-white' : 'bg-gray-200'}`}
+          >
+            Large
+          </button>
+        </div>
+
+        <h2 className="font-semibold mb-2">カラー:</h2>
+        <div className="flex flex-wrap gap-2 mb-6">
+          {colors.map((c) => (
+            <button
+              key={c.value}
+              onClick={() => setColor(c.value)}
+              className="px-3 py-1 rounded border shadow-sm flex items-center"
+              style={{
+                backgroundColor: color === c.value ? c.value : 'white',
+                color: color === c.value ? (
+                  ['#F59E0B', '#10B981'].includes(c.value) ? 'black' : 'white'
+                ) : 'black',
+                borderColor: c.value
+              }}
+            >
+              <div className="w-3 h-3 rounded-full mr-2" style={{ backgroundColor: c.value }}></div>
+              {c.name}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="border border-gray-300 rounded-lg p-8 bg-white shadow-sm">
+        <h2 className="text-lg font-semibold mb-4 text-center">ローディング表示</h2>
+        <div className="h-40 w-full flex items-center justify-center">
+          <Loading size={size} color={color} />
+        </div>
+      </div>
+
+      <div className="mt-8 text-sm text-gray-500">
+        <p>※このページはローディングコンポーネントのテスト用です。</p>
+        <p>実際のアプリケーションでは、データ取得中やページ遷移時などに表示されます。</p>
+      </div>
+    </div>
+  );
+}

--- a/front/src/app/pair/gift_request/page.tsx
+++ b/front/src/app/pair/gift_request/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import React, { useState } from 'react';
 import { FaHeart, FaYenSign } from "react-icons/fa"
 import { GiftRequestTable } from '@/app/pair/components/GiftRequestTable';
 import { useGiftRequests } from '@/hooks/useGiftRequests';

--- a/front/src/app/pair/gift_request/page.tsx
+++ b/front/src/app/pair/gift_request/page.tsx
@@ -6,13 +6,13 @@ import { GiftRequestTable } from '@/app/pair/components/GiftRequestTable';
 import { useGiftRequests } from '@/hooks/useGiftRequests';
 
 export default function GiftRequestPage() {
-  enum RequestType {
-    forParents = "ちょうだい！",
-    fromChildren = "あげる",
-  };
-
-  const { myParentsGiftRequests, myChildrenGiftRequests } = useGiftRequests();
-  const [selectedTab, setSelectedTab] = useState<RequestType.forParents | RequestType.fromChildren>(RequestType.forParents);
+  const {
+    myParentsGiftRequests,
+    myChildrenGiftRequests,
+    selectedTab,
+    setSelectedTab,
+    RequestType
+  } = useGiftRequests();
 
   return(
     <>

--- a/front/src/app/pair/gift_request/page.tsx
+++ b/front/src/app/pair/gift_request/page.tsx
@@ -1,57 +1,18 @@
 "use client";
 
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { FaHeart, FaYenSign } from "react-icons/fa"
-
-import { fetchData } from '@/lib/api';
-
 import { GiftRequestTable } from '@/app/pair/components/GiftRequestTable';
-
-import { ErrorResponse, isErrorResponse } from '@/types/errorResponse';
-import { GiftRequests, GiftRequest } from '@/types/pair';
+import { useGiftRequests } from '@/hooks/useGiftRequests';
 
 export default function GiftRequestPage() {
-  const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/gift_requests`;
+  enum RequestType {
+    forParents = "ちょうだい！",
+    fromChildren = "あげる",
+  };
 
-enum RequestType {
-  forParents = "ちょうだい！",
-  fromChildren = "あげる",
-};
-
-  const [
-    giftRequests, 
-    setGiftRequests
-  ] = useState<GiftRequests | null>(null);
-  const [
-    myParentsGiftRequests, 
-    setMyParentsGiftRequests
-  ] = useState<GiftRequest[]>([]);
-  const [
-    myChildrenGiftRequests, 
-    setMyChildrenGiftRequests
-  ] = useState<GiftRequest[]>([]);
-
+  const { myParentsGiftRequests, myChildrenGiftRequests } = useGiftRequests();
   const [selectedTab, setSelectedTab] = useState<RequestType.forParents | RequestType.fromChildren>(RequestType.forParents);
-
-  useEffect(() => {
-    const fetchShutingsData = async () => {
-      const data = await fetchData<GiftRequests | ErrorResponse>(endpoint, 'GET');
-
-      if (isErrorResponse(data)) {
-        console.error('Error fetching shutings data:', data.message);
-        return;
-      }
-
-      setGiftRequests(data);
-    };
-
-    fetchShutingsData();
-  }, []);
-
-  useEffect(() => {
-    setMyParentsGiftRequests(giftRequests?.myParents || []);
-    setMyChildrenGiftRequests(giftRequests?.myChildren || []);
-  }, [giftRequests])
 
   return(
     <>

--- a/front/src/app/pair/page.tsx
+++ b/front/src/app/pair/page.tsx
@@ -1,84 +1,3 @@
-// "use client";
-
-// import React, { useEffect, useState } from 'react';
-
-// import { fetchData } from '@/lib/api';
-// import { useUser } from '@/context/UserContext';
-// import { ErrorResponse, isErrorResponse } from '@/types/errorResponse';
-// import { Relation } from '@/types/pair';
-
-// import { QrCode } from './components/QrCode';
-// import { PairTable } from '@/app/pair/components/PairTable';
-// import { GiftRequest } from '@/app/pair/components/GiftRequest';
-
-// import { SelectedRelation } from '@/types/pair';
-
-// /*
-//  * TODO:
-//  * user_idで招待をしてしまっているので、IDoor問題あり。
-//  * user_idではなく、都度APIをたたいてトークンをparents_childrenに生成。
-//  * 有効期限もつけ、有効な間だけここに表示。
-//  */
-// export default function Page() {
-//   const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/pairs`;
-//   const frontUrl = `${process.env.NEXT_PUBLIC_FRONT_URL}`;
-
-//   const { userInfo } = useUser();
-//   const [relations, setRelations] = useState<Relation[]>([]);
-//   const [invitationUrl, setInvitationUrl] = useState<string | undefined | null>(null);
-
-//   const [isShowModal, setIsShowModal] = useState<boolean>(false);
-//   const [selectedRelation, setSelectedRelation] = useState<SelectedRelation | null>(null); 
-
-//   useEffect(() => {
-//     const fetchUserData = async () => {
-//       const data = await fetchData<Relation[] | ErrorResponse>(endpoint, 'GET');
-
-//       if (isErrorResponse(data)) {
-//         console.error('Error fetching user data:', data.message);
-//         return;
-//       }
-
-//       console.log(data);
-
-//       setRelations(data);
-//     };
-
-//     fetchUserData();
-//   }, []);
-
-//   useEffect(() => {
-//     if (userInfo) {
-//       setInvitationUrl(`${frontUrl}/invitation?inviteChildUserId=${userInfo?.id}`);
-//     }
-//   }, [userInfo]);
-
-//   useEffect(() => {
-//     console.log(isShowModal);
-//   }, [isShowModal]);
-
-//   return(
-//     <>
-//       {isShowModal && selectedRelation
-//         ? <GiftRequest
-//             parentUserId={selectedRelation.parentUserId} 
-//             parentUserName={selectedRelation.parentUserName} 
-//             isShowModal={isShowModal}
-//             setIsShowModal={setIsShowModal}
-//           />
-//         :
-//           <>
-//             <QrCode invitationUrl={invitationUrl} />
-//             <PairTable
-//               relations={relations}
-//               setSelectedRelation={setSelectedRelation}
-//               setIsShowModal={setIsShowModal}
-//             />
-//           </>
-//       }
-//     </>
-//   );
-// }
 "use client";
 import React, { useState } from 'react';
 import { useUser } from '@/context/UserContext';
@@ -93,7 +12,7 @@ export default function Page() {
   const { userInfo } = useUser();
   const { relations, isLoading, error } = usePairRelations();
   const invitationUrl = useInvitationUrl(userInfo);
-  
+
   const [isShowModal, setIsShowModal] = useState(false);
   const [selectedRelation, setSelectedRelation] = useState<SelectedRelation | null>(null);
 

--- a/front/src/app/pair/page.tsx
+++ b/front/src/app/pair/page.tsx
@@ -1,81 +1,129 @@
+// "use client";
+
+// import React, { useEffect, useState } from 'react';
+
+// import { fetchData } from '@/lib/api';
+// import { useUser } from '@/context/UserContext';
+// import { ErrorResponse, isErrorResponse } from '@/types/errorResponse';
+// import { Relation } from '@/types/pair';
+
+// import { QrCode } from './components/QrCode';
+// import { PairTable } from '@/app/pair/components/PairTable';
+// import { GiftRequest } from '@/app/pair/components/GiftRequest';
+
+// import { SelectedRelation } from '@/types/pair';
+
+// /*
+//  * TODO:
+//  * user_idで招待をしてしまっているので、IDoor問題あり。
+//  * user_idではなく、都度APIをたたいてトークンをparents_childrenに生成。
+//  * 有効期限もつけ、有効な間だけここに表示。
+//  */
+// export default function Page() {
+//   const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/pairs`;
+//   const frontUrl = `${process.env.NEXT_PUBLIC_FRONT_URL}`;
+
+//   const { userInfo } = useUser();
+//   const [relations, setRelations] = useState<Relation[]>([]);
+//   const [invitationUrl, setInvitationUrl] = useState<string | undefined | null>(null);
+
+//   const [isShowModal, setIsShowModal] = useState<boolean>(false);
+//   const [selectedRelation, setSelectedRelation] = useState<SelectedRelation | null>(null); 
+
+//   useEffect(() => {
+//     const fetchUserData = async () => {
+//       const data = await fetchData<Relation[] | ErrorResponse>(endpoint, 'GET');
+
+//       if (isErrorResponse(data)) {
+//         console.error('Error fetching user data:', data.message);
+//         return;
+//       }
+
+//       console.log(data);
+
+//       setRelations(data);
+//     };
+
+//     fetchUserData();
+//   }, []);
+
+//   useEffect(() => {
+//     if (userInfo) {
+//       setInvitationUrl(`${frontUrl}/invitation?inviteChildUserId=${userInfo?.id}`);
+//     }
+//   }, [userInfo]);
+
+//   useEffect(() => {
+//     console.log(isShowModal);
+//   }, [isShowModal]);
+
+//   return(
+//     <>
+//       {isShowModal && selectedRelation
+//         ? <GiftRequest
+//             parentUserId={selectedRelation.parentUserId} 
+//             parentUserName={selectedRelation.parentUserName} 
+//             isShowModal={isShowModal}
+//             setIsShowModal={setIsShowModal}
+//           />
+//         :
+//           <>
+//             <QrCode invitationUrl={invitationUrl} />
+//             <PairTable
+//               relations={relations}
+//               setSelectedRelation={setSelectedRelation}
+//               setIsShowModal={setIsShowModal}
+//             />
+//           </>
+//       }
+//     </>
+//   );
+// }
 "use client";
-
-import React, { useEffect, useState } from 'react';
-
-import { fetchData } from '@/lib/api';
+import React, { useState } from 'react';
 import { useUser } from '@/context/UserContext';
-import { ErrorResponse, isErrorResponse } from '@/types/errorResponse';
-import { Relation } from '@/types/pair';
-
 import { QrCode } from './components/QrCode';
 import { PairTable } from '@/app/pair/components/PairTable';
 import { GiftRequest } from '@/app/pair/components/GiftRequest';
-
 import { SelectedRelation } from '@/types/pair';
+import { usePairRelations } from '@/hooks/usePairRelations';
+import { useInvitationUrl } from '@/hooks/useInvitationUrl';
 
-/*
- * TODO:
- * user_idで招待をしてしまっているので、IDoor問題あり。
- * user_idではなく、都度APIをたたいてトークンをparents_childrenに生成。
- * 有効期限もつけ、有効な間だけここに表示。
- */
 export default function Page() {
-  const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/pairs`;
-  const frontUrl = `${process.env.NEXT_PUBLIC_FRONT_URL}`;
-  
   const { userInfo } = useUser();
-  const [relations, setRelations] = useState<Relation[]>([]);
-  const [invitationUrl, setInvitationUrl] = useState<string | undefined | null>(null);
+  const { relations, isLoading, error } = usePairRelations();
+  const invitationUrl = useInvitationUrl(userInfo);
+  
+  const [isShowModal, setIsShowModal] = useState(false);
+  const [selectedRelation, setSelectedRelation] = useState<SelectedRelation | null>(null);
 
-  const [isShowModal, setIsShowModal] = useState<boolean>(false);
-  const [selectedRelation, setSelectedRelation] = useState<SelectedRelation | null>(null); 
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
 
-  useEffect(() => {
-    const fetchUserData = async () => {
-      const data = await fetchData<Relation[] | ErrorResponse>(endpoint, 'GET');
+  if (error) {
+    return <div>Error: {error}</div>;
+  }
 
-      if (isErrorResponse(data)) {
-        console.error('Error fetching user data:', data.message);
-        return;
-      }
-
-      console.log(data);
-
-      setRelations(data);
-    };
-
-    fetchUserData();
-  }, []);
-
-  useEffect(() => {
-    if (userInfo) {
-      setInvitationUrl(`${frontUrl}/invitation?inviteChildUserId=${userInfo?.id}`);
-    }
-  }, [userInfo]);
-
-  useEffect(() => {
-    console.log(isShowModal);
-  }, [isShowModal]);
-
-  return(
+  return (
     <>
-      {isShowModal && selectedRelation
-        ? <GiftRequest
-            parentUserId={selectedRelation.parentUserId} 
-            parentUserName={selectedRelation.parentUserName} 
-            isShowModal={isShowModal}
+      {isShowModal && selectedRelation ? (
+        <GiftRequest
+          parentUserId={selectedRelation.parentUserId}
+          parentUserName={selectedRelation.parentUserName}
+          isShowModal={isShowModal}
+          setIsShowModal={setIsShowModal}
+        />
+      ) : (
+        <>
+          <QrCode invitationUrl={invitationUrl} />
+          <PairTable
+            relations={relations}
+            setSelectedRelation={setSelectedRelation}
             setIsShowModal={setIsShowModal}
           />
-        :
-          <>
-            <QrCode invitationUrl={invitationUrl} />
-            <PairTable
-              relations={relations}
-              setSelectedRelation={setSelectedRelation}
-              setIsShowModal={setIsShowModal}
-            />
-          </>
-      }
+        </>
+      )}
     </>
   );
 }

--- a/front/src/app/players/page.tsx
+++ b/front/src/app/players/page.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import React from 'react';
+import PlayerCard from '../../components/PlayerCard';
+import { mockPlayers } from '../../data/mockPlayers';
+import useInfiniteScroll from '../../hooks/useInfiniteScroll';
+
+export default function PlayersPage() {
+  // スコア順にプレーヤーをソート
+  const sortedPlayers = [...mockPlayers].sort((a, b) => b.totalScore - a.totalScore);
+
+  // インフィニティスクロールフックを使用
+  const { visibleItems, hasMore, loading, lastElementRef } = useInfiniteScroll(sortedPlayers);
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-800">プレーヤーランキング</h1>
+        <p className="text-gray-600">タイピングゲームのトップスコアプレーヤーです</p>
+      </div>
+
+      <div className="bg-indigo-50 p-6 rounded-lg mb-6">
+        <div className="flex items-center mb-4">
+          <div className="w-8 h-8 rounded-full bg-indigo-500 flex items-center justify-center mr-3">
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-white" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-11a1 1 0 10-2 0v2H7a1 1 0 100 2h2v2a1 1 0 102 0v-2h2a1 1 0 100-2h-2V7z" clipRule="evenodd" />
+            </svg>
+          </div>
+          <h2 className="text-lg font-semibold text-indigo-800">トータルスコアランキング</h2>
+        </div>
+        <p className="text-indigo-700">プレーヤーのスコアランキングを表示しています。下にスクロールすると、さらに表示されます。</p>
+      </div>
+
+      <div className="space-y-3">
+        {visibleItems.map((player, index) => (
+          <div 
+            key={player.id} 
+            ref={index === visibleItems.length - 1 ? lastElementRef : null}
+          >
+            <PlayerCard 
+              player={player} 
+              rank={index + 1}
+            />
+          </div>
+        ))}
+      </div>
+
+      {loading && (
+        <div className="text-center p-4">
+          <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-solid border-indigo-500 border-r-transparent"></div>
+          <p className="mt-2 text-gray-600">読み込み中...</p>
+        </div>
+      )}
+
+      {!hasMore && visibleItems.length > 0 && (
+        <p className="text-center p-4 text-gray-500">
+          すべてのプレーヤーを表示しました
+        </p>
+      )}
+    </div>
+  );
+}

--- a/front/src/app/players/page.tsx
+++ b/front/src/app/players/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import PlayerCard from '../../components/PlayerCard';
 import { mockPlayers } from '../../data/mockPlayers';
 import useInfiniteScroll from '../../hooks/useInfiniteScroll';
@@ -11,6 +11,40 @@ export default function PlayersPage() {
 
   // インフィニティスクロールフックを使用
   const { visibleItems, hasMore, loading, lastElementRef } = useInfiniteScroll(sortedPlayers);
+
+  // ヘッダーリンクの問題を修正するuseEffect
+  useEffect(() => {
+    const fixHeaderLink = () => {
+      // ヘッダーのリンク要素を取得
+      const headerLink = document.querySelector('header a');
+      if (headerLink) {
+        // 既存のクリックイベントリスナーをクリア
+        const newHeaderLink = headerLink.cloneNode(true) as HTMLElement;
+        headerLink.parentNode?.replaceChild(newHeaderLink, headerLink);
+
+        // 新しいクリックイベントリスナーを追加
+        newHeaderLink.addEventListener('click', (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+
+          // /shutingページに強制遷移
+          window.location.href = '/shuting';
+        });
+
+        console.log('Header link fixed for players page');
+      }
+    };
+
+    // ページロード後に実行
+    fixHeaderLink();
+
+    // 少し遅延してもう一度実行（DOMの更新を待つため）
+    const timer = setTimeout(fixHeaderLink, 100);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, []);
 
   return (
     <div className="container mx-auto px-4 py-8">
@@ -33,12 +67,12 @@ export default function PlayersPage() {
 
       <div className="space-y-3">
         {visibleItems.map((player, index) => (
-          <div 
-            key={player.id} 
+          <div
+            key={player.id}
             ref={index === visibleItems.length - 1 ? lastElementRef : null}
           >
             <PlayerCard 
-              player={player} 
+              player={player}
               rank={index + 1}
             />
           </div>

--- a/front/src/app/result/[id]/page.tsx
+++ b/front/src/app/result/[id]/page.tsx
@@ -1,15 +1,14 @@
 "use client"
 
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useParams } from 'next/navigation';
 
-import { fetchData } from '@/lib/api';
 import { Result } from '@/types/result';
 import { Description } from '@/app/result/components/Description';
 import { Chart } from '@/app/result/components/Chart';
 import Loading from "@/components/Loading";
-import { isErrorResponse } from '@/types/errorResponse';
 import { BasicButton } from "@/components/Button";
+import { useResultData } from '@/hooks/useResultData';
 
 export default function Page() {
   const [result, setResult] = useState<Result | null>(null);
@@ -20,36 +19,13 @@ export default function Page() {
   const resultEndpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/results/${id}`;
   const recordsEndpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/shutings/${result?.shuting_id}/results`;
 
-  useEffect(() => {
-    const fetchResult = async () => {
-      const data = await fetchData(resultEndpoint, 'GET');
-
-      if (isErrorResponse(data)) {
-        console.error('Error fetching result data:', data.message);
-	return;
-      }
-
-      setResult(data as Result);
-    };
-
-    fetchResult();
-  }, [resultEndpoint]);
-
-  useEffect(() => {
-    if (result && result?.shuting_id) {
-      const fetchRecords = async () => {
-        const data = await fetchData(recordsEndpoint, 'GET');
-
-        if (Array.isArray(data) && data.every(item => !isErrorResponse(item))) {
-          setRecords(data);
-        } else {
-          console.error('Error fetching records data');
-        }
-      };
-
-      fetchRecords();
-    }
-  }, [result, recordsEndpoint]);
+  useResultData(
+    resultEndpoint,
+    recordsEndpoint,
+    setResult,
+    setRecords,
+    result
+  );
 
   return (
     <div className="justify-center min-h-screen">
@@ -63,8 +39,8 @@ export default function Page() {
           ">レベル{result.shuting_id}</h1>
           <Chart records={records} />
           <Description result={result} />
-          <BasicButton 
-            text='チャレンジ'
+          <BasicButton
+             text='チャレンジ'
             url={`/shuting/${result.shuting_id}`}
           />
         </div>

--- a/front/src/app/result/page.tsx
+++ b/front/src/app/result/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
 
 import { Result } from '@/types/result';
 import { fetchData } from '@/lib/api';
@@ -27,7 +28,7 @@ export default function Page() {
     setSortedResults(
       results
         ?.filter((result) => result.created_at !== undefined)
-        .sort((a, b) => 
+        .sort((a, b) =>
           new Date(b.created_at!).getTime() - new Date(a.created_at!).getTime()
         )
     );
@@ -35,6 +36,15 @@ export default function Page() {
 
   return(
     <div className="overflow-x-auto p-4">
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-xl font-semibold">レコード</h1>
+        <Link
+          href="/players"
+          className="bg-indigo-500 hover:bg-indigo-600 text-white px-3 py-1 rounded text-sm" >
+          ランキングを見る
+        </Link>
+      </div>
+
       {sortedResults ? (
         <ResultTable sortedResults={sortedResults} />
       ) : (

--- a/front/src/app/shuting/page.tsx
+++ b/front/src/app/shuting/page.tsx
@@ -1,34 +1,16 @@
 "use client";
 
-import { 
-  useState, 
-  useEffect, 
-} from 'react';
+import { useState } from 'react';
 import Link from 'next/link';
 
-import { fetchData } from '@/lib/api';
-import { ErrorResponse, isErrorResponse } from '@/types/errorResponse';
 import { Shuting } from '@/types/shuting';
+import { useShutings } from '@/hooks/useShutings';
 
 export default function Page() {
   const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/shutings`;
-
   const [shutings, setShutings] = useState<Shuting[]>([]);
 
-  useEffect(() => {
-    const fetchShutingsData = async () => {
-      const data = await fetchData<Shuting[] | ErrorResponse>(endpoint, 'GET');
-
-      if (isErrorResponse(data)) {
-        console.error('Error fetching shutings data:', data.message);
-        return;
-      }
-
-      setShutings(data);
-    };
-
-    fetchShutingsData();
-  }, []);
+  useShutings(endpoint, setShutings);
 
   return(
     <div>
@@ -57,7 +39,7 @@ const ShutingItem = ({
 }) => {
   return (
     <Link href={`/shuting/${shuting_id}`} key="1">
-      <div 
+      <div
         className="
           h-32
           bg-orange-50

--- a/front/src/app/welcome/layout.tsx
+++ b/front/src/app/welcome/layout.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { RequireAuth } from "@/components/RequireAuth";
+import { SubHeader } from "@/components/SubHeader";
+import { Main } from "@/components/Main";
+import { ListIcon } from "@/components/ListIcon";
+
+export default function Page({children}: {children: React.ReactNode}) {
+  return(
+    <RequireAuth>
+      <SubHeader title="ようこそ">
+        <ListIcon href="/welcome" />
+      </SubHeader>
+      <Main>{children}</Main>
+    </RequireAuth>
+  );
+}

--- a/front/src/app/welcome/privacypolicy/page.tsx
+++ b/front/src/app/welcome/privacypolicy/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import React from 'react';
+
+export default function PrivacypolicyPage() {
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">プライバシーポリシー</h1>
+    </div>
+  );
+}

--- a/front/src/app/welcome/terms/page.tsx
+++ b/front/src/app/welcome/terms/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import React from 'react';
+
+export default function TermsPage() {
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">利用規約</h1>
+    </div>
+  );
+}

--- a/front/src/components/Loading.tsx
+++ b/front/src/components/Loading.tsx
@@ -1,7 +1,41 @@
-export default function Page() {
-  return(
-    <div>
-      <p>Loading...</p>
+import React from "react";
+
+type LoadingProps = {
+  size?: "small" | "medium" | "large";
+  color?: string;
+};
+
+export default function Loading({
+  size = "medium",
+  color = "#6366F1"
+}: LoadingProps) {
+  // サイズに基づいてwidthとheightを設定
+  const dimensions = {
+    small: "w-6 h-6",
+    medium: "w-10 h-10",
+    large: "w-16 h-16"
+  };
+
+  // ボーダーの幅をサイズに合わせて調整
+  const borderWidth = {
+    small: "border-2",
+    medium: "border-4",
+    large: "border-4"
+  };
+
+  return (
+    <div className="flex justify-center items-center h-full w-full">
+      <div
+        className={`
+          ${dimensions[size]}
+          ${borderWidth[size]}
+          border-gray-200
+          border-t-indigo-500
+          rounded-full
+          animate-spin
+        `}
+        style={{ borderTopColor: color }}
+      ></div>
     </div>
   );
 }

--- a/front/src/components/PlayerCard.tsx
+++ b/front/src/components/PlayerCard.tsx
@@ -1,18 +1,61 @@
-import React from 'react';
-import Image from 'next/image';
-import { Player } from '@/data/mockPlayers';
+import React, { useState } from 'react';
+import { Player } from '../data/mockPlayers';
 
 type PlayerCardProps = {
   player: Player;
   rank: number;
 };
 
+// Gravatar風のイニシャルアバター生成関数
+const InitialAvatar = ({ name, size = 40 }: { name: string; size?: number }) => {
+  // 名前の最初の文字を取得（日本語対応）
+  const initial = name.charAt(0).toUpperCase();
+
+  // 名前をベースにした色を生成
+  const getColorFromName = (str: string) => {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      hash = str.charCodeAt(i) + ((hash << 5) - hash);
+    }
+    const colors = [
+      '#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4', '#FFEAA7',
+      '#DDA0DD', '#98D8C8', '#F7DC6F', '#BB8FCE', '#85C1E9',
+      '#F39C12', '#E74C3C', '#9B59B6', '#3498DB', '#1ABC9C',
+      '#2ECC71', '#F1C40F', '#E67E22', '#E91E63', '#9C27B0'
+    ];
+    return colors[Math.abs(hash) % colors.length];
+  };
+
+  return (
+    <div
+      className="flex items-center justify-center w-full h-full rounded-full text-white font-bold shadow-sm"
+      style={{
+        backgroundColor: getColorFromName(name),
+        fontSize: `${size * 0.4}px`
+      }}
+    >
+      {initial}
+    </div>
+  );
+};
+
+// アバターが有効かどうかを判定する関数
+const isValidAvatarUrl = (url: string | null | undefined): boolean => {
+  return !!(url && url.trim() !== '' && url !== 'null' && url !== 'undefined');
+};
+
 const PlayerCard = ({ player, rank }: PlayerCardProps) => {
+  const [imageError, setImageError] = useState(false);
+
+  // アバターURLが有効で、かつ画像読み込みエラーが発生していない場合のみ画像を表示
+  const shouldShowImage = isValidAvatarUrl(player.avatarUrl) && !imageError;
+
   return (
     <div className="flex items-center p-4 bg-white rounded-lg shadow-sm border border-gray-200 mb-3">
+      {/* ランク表示 */}
       <div className="flex-shrink-0 mr-3 w-8 h-8 flex items-center justify-center rounded-full font-bold text-white"
         style={{
-          backgroundColor: 
+          backgroundColor:
             rank === 1 ? '#FFD700' : // 金
             rank === 2 ? '#C0C0C0' : // 銀
             rank === 3 ? '#CD7F32' : // 銅
@@ -21,22 +64,29 @@ const PlayerCard = ({ player, rank }: PlayerCardProps) => {
       >
         {rank}
       </div>
-      
+
+      {/* アバター表示 - 動的判定 */}
       <div className="flex-shrink-0 mr-4">
         <div className="w-10 h-10 rounded-full overflow-hidden relative">
-          <Image 
-            src={player.avatarUrl} 
-            alt={`${player.name}のアバター`}
-            width={40}
-            height={40}
-          />
+          {shouldShowImage ? (
+            <img 
+              src={player.avatarUrl!}
+              alt={`${player.name}のアバター`}
+              className="w-full h-full object-cover"
+              onError={() => setImageError(true)}
+            />
+          ) : (
+            <InitialAvatar name={player.name} size={40} />
+          )}
         </div>
       </div>
-      
+
+      {/* プレイヤー名 */}
       <div className="flex-grow">
         <h3 className="font-semibold text-gray-800">{player.name}</h3>
       </div>
-      
+
+      {/* スコア表示 */}
       <div className="flex-shrink-0 text-right">
         <div className="font-bold text-indigo-600">{player.totalScore.toLocaleString()}</div>
         <div className="text-xs text-gray-500">スコア</div>

--- a/front/src/components/PlayerCard.tsx
+++ b/front/src/components/PlayerCard.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import Image from 'next/image';
+import { Player } from '@/data/mockPlayers';
+
+type PlayerCardProps = {
+  player: Player;
+  rank: number;
+};
+
+const PlayerCard = ({ player, rank }: PlayerCardProps) => {
+  return (
+    <div className="flex items-center p-4 bg-white rounded-lg shadow-sm border border-gray-200 mb-3">
+      <div className="flex-shrink-0 mr-3 w-8 h-8 flex items-center justify-center rounded-full font-bold text-white"
+        style={{
+          backgroundColor: 
+            rank === 1 ? '#FFD700' : // 金
+            rank === 2 ? '#C0C0C0' : // 銀
+            rank === 3 ? '#CD7F32' : // 銅
+            '#6366F1' // その他
+        }}
+      >
+        {rank}
+      </div>
+      
+      <div className="flex-shrink-0 mr-4">
+        <div className="w-10 h-10 rounded-full overflow-hidden relative">
+          <Image 
+            src={player.avatarUrl} 
+            alt={`${player.name}のアバター`}
+            width={40}
+            height={40}
+          />
+        </div>
+      </div>
+      
+      <div className="flex-grow">
+        <h3 className="font-semibold text-gray-800">{player.name}</h3>
+      </div>
+      
+      <div className="flex-shrink-0 text-right">
+        <div className="font-bold text-indigo-600">{player.totalScore.toLocaleString()}</div>
+        <div className="text-xs text-gray-500">スコア</div>
+      </div>
+    </div>
+  );
+};
+
+export default PlayerCard;

--- a/front/src/components/Popup.tsx
+++ b/front/src/components/Popup.tsx
@@ -181,7 +181,7 @@ const FooterArea = () => {
     <div className="mt-4 text-xs text-gray-400 text-center">
       <a href="#" className="hover:underline">プライバシーポリシー</a>
       ・
-      <a href="#" className="hover:underline">利用規約</a>
+      <a href="/welcome/terms" className="hover:underline">利用規約</a>
     </div>
   )
 }

--- a/front/src/components/Popup.tsx
+++ b/front/src/components/Popup.tsx
@@ -179,7 +179,7 @@ const LogoutButton = () => {
 const FooterArea = () => {
   return(
     <div className="mt-4 text-xs text-gray-400 text-center">
-      <a href="#" className="hover:underline">プライバシーポリシー</a>
+      <a href="/welcome/privacypolicy" className="hover:underline">プライバシーポリシー</a>
       ・
       <a href="/welcome/terms" className="hover:underline">利用規約</a>
     </div>

--- a/front/src/context/BackButtonContext.tsx
+++ b/front/src/context/BackButtonContext.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+
+// コンテキストで値の型定義
+type BackButtonContextType = {
+  isBackButtonPressed: boolean;
+  setBackButtonHandler: (handler: (() => void) | null) => void;
+};
+
+// コンテキストの作成
+const BackButtonContext = createContext<BackButtonContextType | undefined>(undefined);
+
+/**
+ * 戻るボタン制御のためのプロバイダーコンポーネント
+ * このコンポーネントでアプリをラップすることで、アプリ内のどこからでも戻るボタンの状態にアクセスできる
+ */
+export const BackButtonProvider = ({ children }: { children: ReactNode }) => {
+  // 戻るボタンが押されたかどうかの状態
+  const [isBackButtonPressed, setIsBackButtonPressed] = useState(false);
+  // 戻るボタンが押された時に実行するカスタムハンドラー
+  const [customHandler, setCustomHandler] = useState<(() => void) | null>(null);
+
+  useEffect(() => {
+    /**
+     * popstateイベントのハンドラー関数
+     * ブラウザの戻るボタンが押された時に呼び出される
+     */
+    const handlePopState = (event: PopStateEvent) => {
+      // 戻るボタンが押されたことを記録
+      setIsBackButtonPressed(true);
+
+      // デバッグ用ログ出力（console.logで出力）
+      console.log('ブラウザの戻るボタンが押されました', event);
+
+      // カスタムハンドラーが設定されていれば実行
+      if (customHandler) {
+        customHandler();
+      }
+
+      // 少し時間を置いてフラグをリセット（連続クリック対策）
+      setTimeout(() => {
+        setIsBackButtonPressed(false);
+      }, 100);
+
+      // 現在のURLを再度pushStateすることで、実際の履歴移動を防ぐ
+      window.history.pushState(null, '', window.location.pathname);
+    };
+
+    // 履歴エントリーを現在のページに追加（これにより「戻る」操作を検知できる）
+    window.history.pushState(null, '', window.location.pathname);
+
+    // ブラウザの「戻る」ボタンイベント（popstate）のリスナー登録
+    window.addEventListener('popstate', handlePopState);
+
+    // コンポーネントのクリーンアップ時にイベントリスナーを削除
+    return () => {
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, [customHandler]); // customHandlerが変更された時に再実行
+
+  /**
+   * 戻るボタンが押された時に実行するカスタムハンドラーを設定する関数
+   * @param handler 実行する関数、またはnull（ハンドラーを削除する場合）
+   */
+  const setBackButtonHandler = (handler: (() => void) | null) => {
+    setCustomHandler(handler);
+  };
+
+  // コンテキストプロバイダーで子コンポーネントをラップ
+  return (
+    <BackButtonContext.Provider value={{ isBackButtonPressed, setBackButtonHandler }}>
+      {children}
+    </BackButtonContext.Provider>
+  );
+};
+
+/**
+ * 戻るボタンの状態とハンドラーにアクセスするためのカスタムフック
+ * コンポーネント内で戻るボタンの状態を取得したり、ハンドラーを設定したりするために使用
+ */
+export const useBackButton = () => {
+  const context = useContext(BackButtonContext);
+
+  // BackButtonProviderの外部で使用された場合はエラー
+  if (context === undefined) {
+    throw new Error('useBackButton must be used within a BackButtonProvider');
+  }
+
+  return context;
+};

--- a/front/src/context/ConfigContext.tsx
+++ b/front/src/context/ConfigContext.tsx
@@ -16,7 +16,6 @@ type ConfigContextType = {
 };
 
 const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/config`;
-// const endpoint = "http://localhost:3000/api/v1/config";
 
 const ConfigContext = createContext<ConfigContextType | null>(null);
 

--- a/front/src/context/ConfigContext.tsx
+++ b/front/src/context/ConfigContext.tsx
@@ -15,8 +15,8 @@ type ConfigContextType = {
   setConfig: React.Dispatch<React.SetStateAction<ConfigItem[]>>;
 };
 
-// const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/config`;
-const endpoint = "http://localhost:3000/api/v1/config";
+const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/config`;
+// const endpoint = "http://localhost:3000/api/v1/config";
 
 const ConfigContext = createContext<ConfigContextType | null>(null);
 

--- a/front/src/data/mockPlayers.ts
+++ b/front/src/data/mockPlayers.ts
@@ -1,0 +1,130 @@
+export type Player = {
+  id: string;
+  name: string;
+  avatarUrl: string;
+  totalScore: number;
+};
+
+// モックプレーヤーデータ
+export const mockPlayers: Player[] = [
+  {
+    id: "1",
+    name: "タイピングマスター",
+    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=1",
+    totalScore: 9850,
+  },
+  {
+    id: "2",
+    name: "キーボードウィザード",
+    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=2",
+    totalScore: 8720,
+  },
+  {
+    id: "3",
+    name: "入力スピードキング",
+    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=3",
+    totalScore: 8450,
+  },
+  {
+    id: "4",
+    name: "文字入力の達人",
+    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=4",
+    totalScore: 7930,
+  },
+  {
+    id: "5",
+    name: "高速タイピスト",
+    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=5",
+    totalScore: 7820,
+  },
+  {
+    id: "6",
+    name: "指の舞ニンジャ",
+    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=6",
+    totalScore: 7650,
+  },
+  {
+    id: "7",
+    name: "キーストロークの女王",
+    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=7",
+    totalScore: 7520,
+  },
+  {
+    id: "8",
+    name: "タイピングチャンピオン",
+    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=8",
+    totalScore: 7350,
+  },
+  {
+    id: "9",
+    name: "キーボードサムライ",
+    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=9",
+    totalScore: 7220,
+  },
+  {
+    id: "10",
+    name: "文字の魔術師",
+    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=10",
+    totalScore: 7080,
+  },
+  {
+    id: "11",
+    name: "クイックフィンガー",
+    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=11",
+    totalScore: 6950,
+  },
+  {
+    id: "12",
+    name: "キーの騎士",
+    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=12",
+    totalScore: 6830,
+  },
+  {
+    id: "13",
+    name: "スピードタイパー",
+    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=13",
+    totalScore: 6710,
+  },
+  {
+    id: "14",
+    name: "フラッシュタイピスト",
+    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=14",
+    totalScore: 6580,
+  },
+  {
+    id: "15",
+    name: "キーボードマエストロ",
+    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=15",
+    totalScore: 6460,
+  },
+  {
+    id: "16",
+    name: "タイプスター",
+    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=16",
+    totalScore: 6330,
+  },
+  {
+    id: "17",
+    name: "入力の魔法使い",
+    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=17",
+    totalScore: 6210,
+  },
+  {
+    id: "18",
+    name: "キーボードレンジャー",
+    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=18",
+    totalScore: 6080,
+  },
+  {
+    id: "19",
+    name: "文字の戦士",
+    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=19",
+    totalScore: 5950,
+  },
+  {
+    id: "20",
+    name: "指先の芸術家",
+    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=20",
+    totalScore: 5830,
+  }
+];

--- a/front/src/data/mockPlayers.ts
+++ b/front/src/data/mockPlayers.ts
@@ -1,130 +1,130 @@
 export type Player = {
   id: string;
   name: string;
-  avatarUrl: string;
+  avatarUrl: string | null; // nullを許可
   totalScore: number;
 };
 
-// モックプレーヤーデータ
+// モックプレーヤーデータ - アバターURLをnullに設定してInitialAvatarを使用
 export const mockPlayers: Player[] = [
   {
     id: "1",
     name: "タイピングマスター",
-    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=1",
+    avatarUrl: null, // Gravatar風アバターを使用
     totalScore: 9850,
   },
   {
     id: "2",
     name: "キーボードウィザード",
-    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=2",
+    avatarUrl: null,
     totalScore: 8720,
   },
   {
     id: "3",
     name: "入力スピードキング",
-    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=3",
+    avatarUrl: null,
     totalScore: 8450,
   },
   {
     id: "4",
     name: "文字入力の達人",
-    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=4",
+    avatarUrl: null,
     totalScore: 7930,
   },
   {
     id: "5",
     name: "高速タイピスト",
-    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=5",
+    avatarUrl: null,
     totalScore: 7820,
   },
   {
     id: "6",
     name: "指の舞ニンジャ",
-    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=6",
+    avatarUrl: null,
     totalScore: 7650,
   },
   {
     id: "7",
-    name: "キーストロークの女王",
-    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=7",
+    name: "キーストローク女王",
+    avatarUrl: null,
     totalScore: 7520,
   },
   {
     id: "8",
     name: "タイピングチャンピオン",
-    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=8",
+    avatarUrl: null,
     totalScore: 7350,
   },
   {
     id: "9",
     name: "キーボードサムライ",
-    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=9",
+    avatarUrl: null,
     totalScore: 7220,
   },
   {
     id: "10",
     name: "文字の魔術師",
-    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=10",
+    avatarUrl: null,
     totalScore: 7080,
   },
   {
     id: "11",
     name: "クイックフィンガー",
-    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=11",
+    avatarUrl: null,
     totalScore: 6950,
   },
   {
     id: "12",
     name: "キーの騎士",
-    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=12",
+    avatarUrl: null,
     totalScore: 6830,
   },
   {
     id: "13",
     name: "スピードタイパー",
-    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=13",
+    avatarUrl: null,
     totalScore: 6710,
   },
   {
     id: "14",
     name: "フラッシュタイピスト",
-    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=14",
+    avatarUrl: null,
     totalScore: 6580,
   },
   {
     id: "15",
     name: "キーボードマエストロ",
-    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=15",
+    avatarUrl: null,
     totalScore: 6460,
   },
   {
     id: "16",
     name: "タイプスター",
-    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=16",
+    avatarUrl: null,
     totalScore: 6330,
   },
   {
     id: "17",
     name: "入力の魔法使い",
-    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=17",
+    avatarUrl: null,
     totalScore: 6210,
   },
   {
     id: "18",
     name: "キーボードレンジャー",
-    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=18",
+    avatarUrl: null,
     totalScore: 6080,
   },
   {
     id: "19",
     name: "文字の戦士",
-    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=19",
+    avatarUrl: null,
     totalScore: 5950,
   },
   {
     id: "20",
     name: "指先の芸術家",
-    avatarUrl: "https://api.dicebear.com/6.x/identicon/svg?seed=20",
+    avatarUrl: null,
     totalScore: 5830,
   }
 ];

--- a/front/src/hooks/useGameState.ts
+++ b/front/src/hooks/useGameState.ts
@@ -1,0 +1,118 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { postData } from '@/lib/api';
+import { Word } from '@/types/shuting';
+import { Result } from '@/types/result';
+import { isErrorResponse } from '@/types/errorResponse';
+import { SoundManager } from '@/app/shuting/components/soundManager';
+import { UserInfo } from '@/types/userInfo';
+
+export const useGameState = (
+  postEndpoint: string,
+  shutingWords: Word[],
+  currentIndex: number,
+  isStart: boolean,
+  time: number,
+  perfectCount: number,
+  result: Result,
+  soundManager: SoundManager,
+  setTime: React.Dispatch<React.SetStateAction<number>>,
+  setIsStart: React.Dispatch<React.SetStateAction<boolean>>,
+  setIsFinish: React.Dispatch<React.SetStateAction<boolean>>,
+  setCurrentWord: React.Dispatch<React.SetStateAction<Word | null>>,
+  setAnswer: React.Dispatch<React.SetStateAction<string>>,
+  setCurrentIndex: React.Dispatch<React.SetStateAction<number>>,
+  setMatchLength: React.Dispatch<React.SetStateAction<number>>,
+  setShutingLimitSec: React.Dispatch<React.SetStateAction<number | null>>,
+  setResult: React.Dispatch<React.SetStateAction<Result>>,
+  setIsFinishOverlayVisible: React.Dispatch<React.SetStateAction<boolean>>,
+  setUserInfo: (updater: (prev: UserInfo | null) => UserInfo | null) => void
+  // setUserInfo: (updater: (prev: any) => any) => void
+) => {
+  const router = useRouter();
+
+  // タイマー用のuseEffect
+  useEffect(() => {
+    let interval: NodeJS.Timeout | undefined;
+
+    if (isStart) {
+      interval = setInterval(() => {
+        setTime((prevTime) => prevTime + 1);
+      }, 1000);
+    } else if (!isStart && time !== 0) {
+      clearInterval(interval);
+    }
+
+    return () => clearInterval(interval);
+  }, [isStart, time, setTime]);
+
+  // 次の問題へ移動する関数
+  const moveToNextExample = () => {
+    const nextIndex = currentIndex + 1;
+
+    if (nextIndex < shutingWords.length) {
+      setCurrentWord(shutingWords[nextIndex]);
+      setAnswer('');
+      setCurrentIndex(nextIndex);
+      setMatchLength(0);
+      setShutingLimitSec(shutingWords[nextIndex].limit_sec || null);
+    } else {
+      handleFinish();
+    }
+  };
+
+  // ゲーム開始関数
+  const handleStart = () => {
+    setTime(0);
+    setIsStart(true);
+    soundManager.playBgm();
+  };
+
+  // ゲーム終了関数
+  const handleFinish = async () => {
+    setIsStart(false);
+    setIsFinish(true);
+    soundManager.stopBgm();
+    soundManager.playFinish();
+
+    const finalResult: Result = {
+      ...result,
+      time: time,
+      perfect_count: perfectCount,
+    };
+
+    try {
+      const data: Result = await postData(postEndpoint, finalResult);
+      if (isErrorResponse(data)) {
+        console.error('API Error:', data.message);
+      } else if (data && 'id' in data) {
+        setResult(prev => ({
+          ...prev,
+          score: data.score,
+          time_bonus: data.time_bonus
+        }));
+	
+        setUserInfo((prev) => ({
+          ...prev,
+          id: prev?.id ?? null,
+          point: data.point ?? 0,
+          total_point: prev?.total_point ?? 0,
+        }));
+
+        setIsFinishOverlayVisible(true);
+        await new Promise(resolve => setTimeout(resolve, 5000));
+        setIsFinishOverlayVisible(false);
+
+        router.push(`/result/${data.id}`);
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return {
+    moveToNextExample,
+    handleStart,
+    handleFinish
+  };
+};

--- a/front/src/hooks/useGameState.ts
+++ b/front/src/hooks/useGameState.ts
@@ -27,7 +27,6 @@ export const useGameState = (
   setResult: React.Dispatch<React.SetStateAction<Result>>,
   setIsFinishOverlayVisible: React.Dispatch<React.SetStateAction<boolean>>,
   setUserInfo: (updater: (prev: UserInfo | null) => UserInfo | null) => void
-  // setUserInfo: (updater: (prev: any) => any) => void
 ) => {
   const router = useRouter();
 

--- a/front/src/hooks/useGiftRequests.ts
+++ b/front/src/hooks/useGiftRequests.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import { fetchData } from '@/lib/api';
+import { ErrorResponse, isErrorResponse } from '@/types/errorResponse';
+import { GiftRequests, GiftRequest } from '@/types/pair';
+
+export const useGiftRequests = () => {
+  const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/gift_requests`;
+  const [giftRequests, setGiftRequests] = useState<GiftRequests | null>(null);
+  const [myParentsGiftRequests, setMyParentsGiftRequests] = useState<GiftRequest[]>([]);
+  const [myChildrenGiftRequests, setMyChildrenGiftRequests] = useState<GiftRequest[]>([]);
+
+  useEffect(() => {
+    const fetchGiftRequestsData = async () => {
+      const data = await fetchData<GiftRequests | ErrorResponse>(endpoint, 'GET');
+
+      if (isErrorResponse(data)) {
+        console.error('Error fetching gift requests data:', data.message);
+        return;
+      }
+
+      setGiftRequests(data);
+    };
+
+    fetchGiftRequestsData();
+  }, []);
+
+  useEffect(() => {
+    setMyParentsGiftRequests(giftRequests?.myParents || []);
+    setMyChildrenGiftRequests(giftRequests?.myChildren || []);
+  }, [giftRequests]);
+
+  return {
+    myParentsGiftRequests,
+    myChildrenGiftRequests
+  };
+};

--- a/front/src/hooks/useGiftRequests.ts
+++ b/front/src/hooks/useGiftRequests.ts
@@ -28,7 +28,7 @@ export const useGiftRequests = () => {
     };
 
     fetchGiftRequestsData();
-  }, []);
+  }, [endpoint]);
 
   useEffect(() => {
     setMyParentsGiftRequests(giftRequests?.myParents || []);

--- a/front/src/hooks/useGiftRequests.ts
+++ b/front/src/hooks/useGiftRequests.ts
@@ -3,11 +3,17 @@ import { fetchData } from '@/lib/api';
 import { ErrorResponse, isErrorResponse } from '@/types/errorResponse';
 import { GiftRequests, GiftRequest } from '@/types/pair';
 
+export enum RequestType {
+  forParents = "ちょうだい！",
+  fromChildren = "あげる",
+}
+
 export const useGiftRequests = () => {
   const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/gift_requests`;
   const [giftRequests, setGiftRequests] = useState<GiftRequests | null>(null);
   const [myParentsGiftRequests, setMyParentsGiftRequests] = useState<GiftRequest[]>([]);
   const [myChildrenGiftRequests, setMyChildrenGiftRequests] = useState<GiftRequest[]>([]);
+  const [selectedTab, setSelectedTab] = useState<RequestType>(RequestType.forParents);
 
   useEffect(() => {
     const fetchGiftRequestsData = async () => {
@@ -31,6 +37,9 @@ export const useGiftRequests = () => {
 
   return {
     myParentsGiftRequests,
-    myChildrenGiftRequests
+    myChildrenGiftRequests,
+    selectedTab,
+    setSelectedTab,
+    RequestType
   };
 };

--- a/front/src/hooks/useInfiniteScroll.ts
+++ b/front/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,55 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+export function useInfiniteScroll<T>(
+  allItems: T[],
+  initialItemsCount: number = 20,
+  loadMoreCount: number = 10
+) {
+  const [visibleItems, setVisibleItems] = useState<T[]>([]);
+  const [hasMore, setHasMore] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const observer = useRef<IntersectionObserver | null>(null);
+
+  // 初期アイテムをロード
+  useEffect(() => {
+    setVisibleItems(allItems.slice(0, initialItemsCount));
+    setHasMore(allItems.length > initialItemsCount);
+  }, [allItems, initialItemsCount]);
+
+  // アイテムをもっと読み込む
+  const loadMore = useCallback(() => {
+    if (loading || !hasMore) return;
+
+    setLoading(true);
+    
+    // 読み込みの遅延をシミュレート
+    setTimeout(() => {
+      const nextItems = allItems.slice(visibleItems.length, visibleItems.length + loadMoreCount);
+      setVisibleItems(prev => [...prev, ...nextItems]);
+      setHasMore(visibleItems.length + nextItems.length < allItems.length);
+      setLoading(false);
+    }, 300);
+  }, [allItems, visibleItems.length, hasMore, loading, loadMoreCount]);
+
+  // 最後の要素に対するコールバックレフ
+  const lastElementRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (loading) return;
+      
+      if (observer.current) observer.current.disconnect();
+      
+      observer.current = new IntersectionObserver(entries => {
+        if (entries[0].isIntersecting && hasMore) {
+          loadMore();
+        }
+      });
+      
+      if (node) observer.current.observe(node);
+    },
+    [loading, hasMore, loadMore]
+  );
+
+  return { visibleItems, hasMore, loading, loadMore, lastElementRef };
+}
+
+export default useInfiniteScroll;

--- a/front/src/hooks/useInvitationUrl.ts
+++ b/front/src/hooks/useInvitationUrl.ts
@@ -1,0 +1,15 @@
+import { useState, useEffect } from 'react';
+import { UserInfo } from '@/types/userInfo';
+
+export const useInvitationUrl = (userInfo: UserInfo | null) => {
+  const [invitationUrl, setInvitationUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (userInfo) {
+      const frontUrl = process.env.NEXT_PUBLIC_FRONT_URL;
+      setInvitationUrl(`${frontUrl}/invitation?inviteChildUserId=${userInfo.id}`);
+    }
+  }, [userInfo]);
+
+  return invitationUrl;
+};

--- a/front/src/hooks/usePairRelations.ts
+++ b/front/src/hooks/usePairRelations.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect } from 'react';
+import { fetchData } from '@/lib/api';
+import { Relation } from '@/types/pair';
+import { ErrorResponse, isErrorResponse } from '@/types/errorResponse';
+
+export const usePairRelations = () => {
+  const [relations, setRelations] = useState<Relation[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const endpoint = `${process.env.NEXT_PUBLIC_API_ENDPOINT_URL}/user/pairs`;
+
+  useEffect(() => {
+    const fetchRelations = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const data = await fetchData<Relation[] | ErrorResponse>(endpoint, 'GET');
+
+        if (isErrorResponse(data)) {
+          setError(data.message || data.error_type || 'Unknown error');
+          return;
+        }
+
+        setRelations(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'An error occurred');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchRelations();
+  }, []);
+
+  return { relations, isLoading, error };
+};

--- a/front/src/hooks/useResultData.ts
+++ b/front/src/hooks/useResultData.ts
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+import { fetchData } from '@/lib/api';
+import { Result } from '@/types/result';
+import { isErrorResponse } from '@/types/errorResponse';
+
+export const useResultData = (
+  resultEndpoint: string,
+  recordsEndpoint: string,
+  setResult: React.Dispatch<React.SetStateAction<Result | null>>,
+  setRecords: React.Dispatch<React.SetStateAction<Result[]>>,
+  result: Result | null
+) => {
+  // 結果データを取得するuseEffect
+  useEffect(() => {
+    const fetchResult = async () => {
+      const data = await fetchData(resultEndpoint, 'GET');
+
+      if (isErrorResponse(data)) {
+        console.error('Error fetching result data:', data.message);
+        return;
+      }
+
+      setResult(data as Result);
+    };
+
+    fetchResult();
+  }, [resultEndpoint, setResult]);
+
+  // 履歴データを取得するuseEffect
+  useEffect(() => {
+    if (result && result?.shuting_id) {
+      const fetchRecords = async () => {
+        const data = await fetchData(recordsEndpoint, 'GET');
+
+        if (Array.isArray(data) && data.every(item => !isErrorResponse(item))) {
+          setRecords(data);
+        } else {
+          console.error('Error fetching records data');
+        }
+      };
+
+      fetchRecords();
+    }
+  }, [result, recordsEndpoint, setRecords]);
+};

--- a/front/src/hooks/useShutingData.ts
+++ b/front/src/hooks/useShutingData.ts
@@ -1,0 +1,46 @@
+import { useEffect } from 'react';
+import { fetchData } from '@/lib/api';
+import { Shuting, Word } from '@/types/shuting';
+import { isErrorResponse } from '@/types/errorResponse';
+import { SoundManager } from '@/app/shuting/components/soundManager';
+
+export const useShutingData = (
+  getEndpoint: string,
+  currentIndex: number,
+  setShutingWords: React.Dispatch<React.SetStateAction<Word[]>>,
+  setCurrentWord: React.Dispatch<React.SetStateAction<Word | null>>,
+  setShutingLimitSec: React.Dispatch<React.SetStateAction<number | null>>,
+  soundManager: SoundManager
+) => {
+  // データ取得用のuseEffect
+  useEffect(() => {
+    const fetchShutings = async () => {
+      const data: Shuting = await fetchData(getEndpoint, 'GET');
+
+      if (isErrorResponse(data)) {
+        console.error('Error fetching lesson data:', data.message);
+        return;
+      };
+
+      console.log(data.words)
+
+      if (Array.isArray(data.words)) {
+        const words: Word[] = data.is_random
+          ? [...data.words].sort(() => Math.random() - 0.5)
+          : data.words;
+
+        setShutingWords(words);
+        setCurrentWord(words[currentIndex]);
+        setShutingLimitSec(words[currentIndex]?.limit_sec);
+      } else {
+        console.error("Expected an array of words, received:", data.words);
+      }
+    };
+
+    fetchShutings();
+
+    soundManager.playReadyGo();
+  // マウント時に一度だけデータを取得したいため、依存配列は空にしています
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+};

--- a/front/src/hooks/useShutings.ts
+++ b/front/src/hooks/useShutings.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { fetchData } from '@/lib/api';
+import { ErrorResponse, isErrorResponse } from '@/types/errorResponse';
+import { Shuting } from '@/types/shuting';
+
+export const useShutings = (
+  endpoint: string,
+  setShutings: React.Dispatch<React.SetStateAction<Shuting[]>>
+) => {
+  useEffect(() => {
+    const fetchShutingsData = async () => {
+      const data = await fetchData<Shuting[] | ErrorResponse>(endpoint, 'GET');
+
+      if (isErrorResponse(data)) {
+        console.error('Error fetching shutings data:', data.message);
+        return;
+      }
+
+      setShutings(data);
+    };
+
+    fetchShutingsData();
+  }, [endpoint, setShutings]);
+};


### PR DESCRIPTION
# WHY
https://github.com/yokohama/typing/issues/31

# WHAT
このPRでは、タイピングゲームのプレーヤーランキングページを実装しています。
トップ20プレーヤーのランキングを表示するシンプルな画面を作成しました。

## 変更内容
- モックプレーヤーデータの作成
- プレーヤーカードコンポーネントの実装
- ランキングページの実装
- 個人スコアページにランキングページのリンクの追加

![スクリーンショット 2025-05-11 21 28 57](https://github.com/user-attachments/assets/610b8dcd-9ae5-438a-a18e-c7c270caa98f)


![スクリーンショット 2025-05-18 0 55 20](https://github.com/user-attachments/assets/ed587534-1246-40b0-869e-c21971b7d769)


